### PR TITLE
[codex] Task 1 bootstrap schema and shared types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,10 +31,14 @@ Do not silently change architecture, stack, role model, API shape, or data contr
 ### Backend
 
 - Keep backend code in the root Spring Boot project under `src/main/java`.
+- Use Java 17 with Spring Boot 4.x conventions already present in `pom.xml`.
 - Use MyBatis for persistence.
+- Use Lombok where the project already relies on it for boilerplate reduction.
+- Do not introduce Java `record` types for backend DTO, VO, entity, or response objects unless the user explicitly asks for them.
 - Prefer lightweight interceptor-based auth for MVP instead of introducing full Spring Security unless the user requests it.
 - Use H2-backed integration tests for backend verification where the plan calls for them.
 - Keep shared enums, DTOs, VOs, and response wrappers aligned with the plan.
+- Keep backend code style aligned with the existing stack in `pom.xml`, including MySQL, H2, and the currently declared Redis support.
 
 ### Frontend
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>mybatis-spring-boot-starter</artifactId>
             <version>4.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -83,6 +87,11 @@
             <groupId>org.mybatis.spring.boot</groupId>
             <artifactId>mybatis-spring-boot-starter-test</artifactId>
             <version>4.0.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/edu/tobserver/common/api/ApiResponse.java
+++ b/src/main/java/com/edu/tobserver/common/api/ApiResponse.java
@@ -1,0 +1,16 @@
+package com.edu.tobserver.common.api;
+
+public record ApiResponse<T>(int code, String message, T data) {
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(200, "success", data);
+    }
+
+    public static ApiResponse<Void> successMessage(String message) {
+        return new ApiResponse<>(200, message, null);
+    }
+
+    public static ApiResponse<Void> failure(int code, String message) {
+        return new ApiResponse<>(code, message, null);
+    }
+}

--- a/src/main/java/com/edu/tobserver/common/api/ApiResponse.java
+++ b/src/main/java/com/edu/tobserver/common/api/ApiResponse.java
@@ -1,6 +1,15 @@
 package com.edu.tobserver.common.api;
 
-public record ApiResponse<T>(int code, String message, T data) {
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    private final int code;
+    private final String message;
+    private final T data;
 
     public static <T> ApiResponse<T> success(T data) {
         return new ApiResponse<>(200, "success", data);

--- a/src/main/java/com/edu/tobserver/common/enums/DimensionCode.java
+++ b/src/main/java/com/edu/tobserver/common/enums/DimensionCode.java
@@ -1,0 +1,9 @@
+package com.edu.tobserver.common.enums;
+
+public enum DimensionCode {
+    TEACHING_DESIGN,
+    CLASSROOM_ORGANIZATION,
+    TEACHING_CONTENT,
+    INTERACTION_FEEDBACK,
+    TEACHING_EFFECTIVENESS
+}

--- a/src/main/java/com/edu/tobserver/common/enums/RecordStatus.java
+++ b/src/main/java/com/edu/tobserver/common/enums/RecordStatus.java
@@ -1,0 +1,8 @@
+package com.edu.tobserver.common.enums;
+
+public enum RecordStatus {
+    DRAFT,
+    SUBMITTED,
+    RETURNED,
+    APPROVED
+}

--- a/src/main/java/com/edu/tobserver/common/enums/RoleCode.java
+++ b/src/main/java/com/edu/tobserver/common/enums/RoleCode.java
@@ -1,0 +1,7 @@
+package com.edu.tobserver.common.enums;
+
+public enum RoleCode {
+    LEADER,
+    MEMBER,
+    ADMIN
+}

--- a/src/main/java/com/edu/tobserver/common/enums/TaskStatus.java
+++ b/src/main/java/com/edu/tobserver/common/enums/TaskStatus.java
@@ -1,0 +1,7 @@
+package com.edu.tobserver.common.enums;
+
+public enum TaskStatus {
+    PENDING,
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=T-Observer
 spring.datasource.url=jdbc:mysql://localhost:3306/t_observer?useSSL=false&serverTimezone=Asia/Shanghai&characterEncoding=utf8
 spring.datasource.username=root
-spring.datasource.password=123456
+spring.datasource.password=root
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.sql.init.mode=always
 spring.sql.init.encoding=UTF-8

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 spring.application.name=T-Observer
+spring.datasource.url=jdbc:mysql://localhost:3306/t_observer?useSSL=false&serverTimezone=Asia/Shanghai&characterEncoding=utf8
+spring.datasource.username=root
+spring.datasource.password=123456
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.sql.init.mode=always
+spring.sql.init.encoding=UTF-8
+mybatis.configuration.map-underscore-to-camel-case=true

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,35 @@
+insert into sys_user (username, password, real_name, role_code, status)
+select 'leader01', '123456', 'Leader One', 'LEADER', 'ACTIVE'
+where not exists (select 1 from sys_user where username = 'leader01');
+
+insert into sys_user (username, password, real_name, role_code, status)
+select 'member01', '123456', 'Member One', 'MEMBER', 'ACTIVE'
+where not exists (select 1 from sys_user where username = 'member01');
+
+insert into sys_user (username, password, real_name, role_code, status)
+select 'member02', '123456', 'Member Two', 'MEMBER', 'ACTIVE'
+where not exists (select 1 from sys_user where username = 'member02');
+
+insert into sys_user (username, password, real_name, role_code, status)
+select 'admin01', '123456', 'Admin One', 'ADMIN', 'ACTIVE'
+where not exists (select 1 from sys_user where username = 'admin01');
+
+insert into evaluation_dimension (dimension_code, dimension_name)
+select 'TEACHING_DESIGN', 'Teaching Design'
+where not exists (select 1 from evaluation_dimension where dimension_code = 'TEACHING_DESIGN');
+
+insert into evaluation_dimension (dimension_code, dimension_name)
+select 'CLASSROOM_ORGANIZATION', 'Classroom Organization'
+where not exists (select 1 from evaluation_dimension where dimension_code = 'CLASSROOM_ORGANIZATION');
+
+insert into evaluation_dimension (dimension_code, dimension_name)
+select 'TEACHING_CONTENT', 'Teaching Content'
+where not exists (select 1 from evaluation_dimension where dimension_code = 'TEACHING_CONTENT');
+
+insert into evaluation_dimension (dimension_code, dimension_name)
+select 'INTERACTION_FEEDBACK', 'Interaction Feedback'
+where not exists (select 1 from evaluation_dimension where dimension_code = 'INTERACTION_FEEDBACK');
+
+insert into evaluation_dimension (dimension_code, dimension_name)
+select 'TEACHING_EFFECTIVENESS', 'Teaching Effectiveness'
+where not exists (select 1 from evaluation_dimension where dimension_code = 'TEACHING_EFFECTIVENESS');

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,14 @@
+create table if not exists sys_user (
+    id bigint primary key auto_increment,
+    username varchar(64) not null unique,
+    password varchar(128) not null,
+    real_name varchar(64) not null,
+    role_code varchar(32) not null,
+    status varchar(32) not null
+);
+
+create table if not exists evaluation_dimension (
+    id bigint primary key auto_increment,
+    dimension_code varchar(64) not null unique,
+    dimension_name varchar(64) not null
+);

--- a/src/test/java/com/edu/tobserver/bootstrap/BootstrapDataTest.java
+++ b/src/test/java/com/edu/tobserver/bootstrap/BootstrapDataTest.java
@@ -1,0 +1,35 @@
+package com.edu.tobserver.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class BootstrapDataTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void shouldLoadSeedUsersAndDimensions() {
+        Integer userCount = jdbcTemplate.queryForObject("select count(*) from sys_user", Integer.class);
+        Integer dimensionCount = jdbcTemplate.queryForObject("select count(*) from evaluation_dimension", Integer.class);
+        List<String> seededUsers = jdbcTemplate.query(
+                "select username, role_code from sys_user where username in ('leader01', 'member01') order by username",
+                (rs, rowNum) -> rs.getString("username") + ":" + rs.getString("role_code"));
+        List<String> seededDimensions = jdbcTemplate.query(
+                "select dimension_code from evaluation_dimension where dimension_code in ('TEACHING_DESIGN', 'TEACHING_EFFECTIVENESS') order by dimension_code",
+                (rs, rowNum) -> rs.getString("dimension_code"));
+
+        assertThat(userCount).isEqualTo(4);
+        assertThat(dimensionCount).isEqualTo(5);
+        assertThat(seededUsers).containsExactly("leader01:LEADER", "member01:MEMBER");
+        assertThat(seededDimensions).containsExactly("TEACHING_DESIGN", "TEACHING_EFFECTIVENESS");
+    }
+}

--- a/src/test/java/com/edu/tobserver/common/api/ApiResponseTest.java
+++ b/src/test/java/com/edu/tobserver/common/api/ApiResponseTest.java
@@ -1,0 +1,26 @@
+package com.edu.tobserver.common.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ApiResponseTest {
+
+    @Test
+    void shouldCreateSuccessResponse() {
+        ApiResponse<String> response = ApiResponse.success("payload");
+
+        assertThat(response.getCode()).isEqualTo(200);
+        assertThat(response.getMessage()).isEqualTo("success");
+        assertThat(response.getData()).isEqualTo("payload");
+    }
+
+    @Test
+    void shouldCreateFailureResponseWithoutData() {
+        ApiResponse<Void> response = ApiResponse.failure(400, "bad request");
+
+        assertThat(response.getCode()).isEqualTo(400);
+        assertThat(response.getMessage()).isEqualTo("bad request");
+        assertThat(response.getData()).isNull();
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:tobserver;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driver-class-name=org.h2.Driver
+spring.sql.init.mode=always
+mybatis.configuration.map-underscore-to-camel-case=true


### PR DESCRIPTION
Implements MVP Task 1 and closes #1.

## What changed
- added bootstrap schema and seed SQL for users and evaluation dimensions
- added shared API response and enum types used by later tasks
- added H2-backed test configuration for repeatable backend tests
- added BootstrapDataTest and strengthened it to verify concrete seed values

## Verification
- cmd /c ".\mvnw.cmd -Dspring.profiles.active=test -Dtest=BootstrapDataTest test"

## Notes
- SQL bootstrap was made idempotent enough for repeated initialization while keeping Task 1 scope focused
- Redis starters were left untouched because they predate this task and were not needed to satisfy Task 1
