### PR TITLE
[codex] Task2 add local login endpoints

### DIFF
--- a/src/main/java/com/edu/tobserver/auth/config/AuthInterceptor.java
+++ b/src/main/java/com/edu/tobserver/auth/config/AuthInterceptor.java
@@ -1,0 +1,43 @@
+package com.edu.tobserver.auth.config;
+
+import com.edu.tobserver.auth.service.TokenSessionService;
+import com.edu.tobserver.common.context.LoginUser;
+import com.edu.tobserver.common.context.LoginUserContext;
+import com.edu.tobserver.common.exception.BusinessException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private static final String TOKEN_HEADER = "X-Auth-Token";
+
+    private final TokenSessionService tokenSessionService;
+
+    public AuthInterceptor(TokenSessionService tokenSessionService) {
+        this.tokenSessionService = tokenSessionService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String token = request.getHeader(TOKEN_HEADER);
+        if (token == null || token.isBlank()) {
+            throw new BusinessException(401, "未登录或登录已过期");
+        }
+
+        LoginUser loginUser = tokenSessionService.get(token);
+        if (loginUser == null) {
+            throw new BusinessException(401, "未登录或登录已过期");
+        }
+
+        LoginUserContext.set(loginUser);
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+        LoginUserContext.clear();
+    }
+}

--- a/src/main/java/com/edu/tobserver/auth/config/WebMvcConfig.java
+++ b/src/main/java/com/edu/tobserver/auth/config/WebMvcConfig.java
@@ -1,0 +1,22 @@
+package com.edu.tobserver.auth.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+
+    public WebMvcConfig(AuthInterceptor authInterceptor) {
+        this.authInterceptor = authInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/api/**")
+                .excludePathPatterns("/api/auth/login");
+    }
+}

--- a/src/main/java/com/edu/tobserver/auth/controller/AuthController.java
+++ b/src/main/java/com/edu/tobserver/auth/controller/AuthController.java
@@ -1,0 +1,34 @@
+package com.edu.tobserver.auth.controller;
+
+import com.edu.tobserver.auth.dto.LoginRequest;
+import com.edu.tobserver.auth.service.AuthService;
+import com.edu.tobserver.auth.vo.CurrentUserVo;
+import com.edu.tobserver.auth.vo.LoginResponse;
+import com.edu.tobserver.common.api.ApiResponse;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ApiResponse.success(authService.login(request));
+    }
+
+    @GetMapping("/me")
+    public ApiResponse<CurrentUserVo> currentUser() {
+        return ApiResponse.success(authService.currentUser());
+    }
+}

--- a/src/main/java/com/edu/tobserver/auth/dto/LoginRequest.java
+++ b/src/main/java/com/edu/tobserver/auth/dto/LoginRequest.java
@@ -1,0 +1,18 @@
+package com.edu.tobserver.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+
+    @NotBlank(message = "用户名不能为空")
+    private String username;
+
+    @NotBlank(message = "密码不能为空")
+    private String password;
+}

--- a/src/main/java/com/edu/tobserver/auth/entity/SysUser.java
+++ b/src/main/java/com/edu/tobserver/auth/entity/SysUser.java
@@ -1,0 +1,15 @@
+package com.edu.tobserver.auth.entity;
+
+import com.edu.tobserver.common.enums.RoleCode;
+import lombok.Data;
+
+@Data
+public class SysUser {
+
+    private Long id;
+    private String username;
+    private String password;
+    private String realName;
+    private RoleCode roleCode;
+    private String status;
+}

--- a/src/main/java/com/edu/tobserver/auth/mapper/UserMapper.java
+++ b/src/main/java/com/edu/tobserver/auth/mapper/UserMapper.java
@@ -1,0 +1,16 @@
+package com.edu.tobserver.auth.mapper;
+
+import com.edu.tobserver.auth.entity.SysUser;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+@Mapper
+public interface UserMapper {
+
+    @Select("""
+            select id, username, password, real_name, role_code, status
+            from sys_user
+            where username = #{username}
+            """)
+    SysUser findByUsername(String username);
+}

--- a/src/main/java/com/edu/tobserver/auth/service/AuthService.java
+++ b/src/main/java/com/edu/tobserver/auth/service/AuthService.java
@@ -1,0 +1,54 @@
+package com.edu.tobserver.auth.service;
+
+import com.edu.tobserver.auth.dto.LoginRequest;
+import com.edu.tobserver.auth.entity.SysUser;
+import com.edu.tobserver.auth.mapper.UserMapper;
+import com.edu.tobserver.auth.vo.CurrentUserVo;
+import com.edu.tobserver.auth.vo.LoginResponse;
+import com.edu.tobserver.common.context.LoginUser;
+import com.edu.tobserver.common.context.LoginUserContext;
+import com.edu.tobserver.common.exception.BusinessException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+
+    private final UserMapper userMapper;
+    private final TokenSessionService tokenSessionService;
+
+    public AuthService(UserMapper userMapper, TokenSessionService tokenSessionService) {
+        this.userMapper = userMapper;
+        this.tokenSessionService = tokenSessionService;
+    }
+
+    public LoginResponse login(LoginRequest request) {
+        SysUser sysUser = userMapper.findByUsername(request.getUsername());
+        if (sysUser == null || !sysUser.getPassword().equals(request.getPassword()) || !"ACTIVE".equals(sysUser.getStatus())) {
+            throw new BusinessException(401, "用户名或密码错误");
+        }
+
+        LoginUser loginUser = new LoginUser(
+                sysUser.getId(),
+                sysUser.getUsername(),
+                sysUser.getRealName(),
+                sysUser.getRoleCode()
+        );
+        String token = tokenSessionService.create(loginUser);
+        return LoginResponse.builder()
+                .token(token)
+                .userId(sysUser.getId())
+                .realName(sysUser.getRealName())
+                .roleCode(sysUser.getRoleCode())
+                .build();
+    }
+
+    public CurrentUserVo currentUser() {
+        LoginUser loginUser = LoginUserContext.getRequired();
+        return CurrentUserVo.builder()
+                .userId(loginUser.getUserId())
+                .username(loginUser.getUsername())
+                .realName(loginUser.getRealName())
+                .roleCode(loginUser.getRoleCode())
+                .build();
+    }
+}

--- a/src/main/java/com/edu/tobserver/auth/service/TokenSessionService.java
+++ b/src/main/java/com/edu/tobserver/auth/service/TokenSessionService.java
@@ -1,0 +1,23 @@
+package com.edu.tobserver.auth.service;
+
+import com.edu.tobserver.common.context.LoginUser;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TokenSessionService {
+
+    private final Map<String, LoginUser> sessions = new ConcurrentHashMap<>();
+
+    public String create(LoginUser loginUser) {
+        String token = UUID.randomUUID().toString();
+        sessions.put(token, loginUser);
+        return token;
+    }
+
+    public LoginUser get(String token) {
+        return sessions.get(token);
+    }
+}

--- a/src/main/java/com/edu/tobserver/auth/vo/CurrentUserVo.java
+++ b/src/main/java/com/edu/tobserver/auth/vo/CurrentUserVo.java
@@ -1,0 +1,19 @@
+package com.edu.tobserver.auth.vo;
+
+import com.edu.tobserver.common.enums.RoleCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CurrentUserVo {
+
+    private Long userId;
+    private String username;
+    private String realName;
+    private RoleCode roleCode;
+}

--- a/src/main/java/com/edu/tobserver/auth/vo/LoginResponse.java
+++ b/src/main/java/com/edu/tobserver/auth/vo/LoginResponse.java
@@ -1,0 +1,19 @@
+package com.edu.tobserver.auth.vo;
+
+import com.edu.tobserver.common.enums.RoleCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponse {
+
+    private String token;
+    private Long userId;
+    private String realName;
+    private RoleCode roleCode;
+}

--- a/src/main/java/com/edu/tobserver/common/context/LoginUser.java
+++ b/src/main/java/com/edu/tobserver/common/context/LoginUser.java
@@ -1,0 +1,15 @@
+package com.edu.tobserver.common.context;
+
+import com.edu.tobserver.common.enums.RoleCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginUser {
+
+    private final Long userId;
+    private final String username;
+    private final String realName;
+    private final RoleCode roleCode;
+}

--- a/src/main/java/com/edu/tobserver/common/context/LoginUserContext.java
+++ b/src/main/java/com/edu/tobserver/common/context/LoginUserContext.java
@@ -1,0 +1,27 @@
+package com.edu.tobserver.common.context;
+
+import com.edu.tobserver.common.exception.BusinessException;
+
+public final class LoginUserContext {
+
+    private static final ThreadLocal<LoginUser> CONTEXT = new ThreadLocal<>();
+
+    private LoginUserContext() {
+    }
+
+    public static void set(LoginUser loginUser) {
+        CONTEXT.set(loginUser);
+    }
+
+    public static LoginUser getRequired() {
+        LoginUser loginUser = CONTEXT.get();
+        if (loginUser == null) {
+            throw new BusinessException(401, "未登录或登录已过期");
+        }
+        return loginUser;
+    }
+
+    public static void clear() {
+        CONTEXT.remove();
+    }
+}

--- a/src/main/java/com/edu/tobserver/common/exception/BusinessException.java
+++ b/src/main/java/com/edu/tobserver/common/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.edu.tobserver.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final int code;
+
+    public BusinessException(int code, String message) {
+        super(message);
+        this.code = code;
+    }
+}

--- a/src/main/java/com/edu/tobserver/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/edu/tobserver/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.edu.tobserver.common.exception;
+
+import com.edu.tobserver.common.api.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException exception) {
+        HttpStatus httpStatus = HttpStatus.resolve(exception.getCode());
+        if (httpStatus == null) {
+            httpStatus = HttpStatus.BAD_REQUEST;
+        }
+        return ResponseEntity.status(httpStatus)
+                .body(ApiResponse.failure(exception.getCode(), exception.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException exception) {
+        FieldError fieldError = exception.getBindingResult().getFieldError();
+        String message = fieldError != null ? fieldError.getDefaultMessage() : "请求参数校验失败";
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.failure(400, message));
+    }
+}

--- a/src/test/java/com/edu/tobserver/auth/AuthControllerTest.java
+++ b/src/test/java/com/edu/tobserver/auth/AuthControllerTest.java
@@ -1,0 +1,50 @@
+package com.edu.tobserver.auth;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class AuthControllerTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
+
+    @Test
+    void shouldLoginWithValidCredentials() throws Exception {
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"username":"leader01","password":"123456"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.token").isNotEmpty())
+                .andExpect(jsonPath("$.data.roleCode").value("LEADER"));
+    }
+
+    @Test
+    void shouldRejectCurrentUserWithoutToken() throws Exception {
+        mockMvc.perform(get("/api/auth/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("未登录或登录已过期"));
+    }
+}


### PR DESCRIPTION
## Summary
- add Task 2 local login backend endpoints and current-user lookup
- add in-memory token session handling, request interception, and login context
- add auth integration tests covering login success and unauthorized /api/auth/me

## Why
- implements MVP Task 2 and GitHub issue #2
- establishes the backend auth contract needed by later task, record, review, and frontend flows

## Validation
- .\mvnw.cmd "-Dspring.profiles.active=test" "-Dtest=BootstrapDataTest,AuthControllerTest" test