### PR TITLE
[codex] Task3 add observation task management backend

### DIFF
--- a/src/main/java/com/edu/tobserver/audit/entity/AuditLog.java
+++ b/src/main/java/com/edu/tobserver/audit/entity/AuditLog.java
@@ -1,0 +1,17 @@
+package com.edu.tobserver.audit.entity;
+
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class AuditLog {
+
+    private Long id;
+    private String bizType;
+    private Long bizId;
+    private String operationType;
+    private Long operatorId;
+    private String operatorName;
+    private String content;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/edu/tobserver/audit/mapper/AuditLogMapper.java
+++ b/src/main/java/com/edu/tobserver/audit/mapper/AuditLogMapper.java
@@ -1,0 +1,19 @@
+package com.edu.tobserver.audit.mapper;
+
+import com.edu.tobserver.audit.entity.AuditLog;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+
+@Mapper
+public interface AuditLogMapper {
+
+    @Insert("""
+            insert into audit_log
+                (biz_type, biz_id, operation_type, operator_id, operator_name, content)
+            values
+                (#{bizType}, #{bizId}, #{operationType}, #{operatorId}, #{operatorName}, #{content})
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "id")
+    int insert(AuditLog auditLog);
+}

--- a/src/main/java/com/edu/tobserver/audit/service/AuditLogService.java
+++ b/src/main/java/com/edu/tobserver/audit/service/AuditLogService.java
@@ -1,0 +1,29 @@
+package com.edu.tobserver.audit.service;
+
+import com.edu.tobserver.audit.entity.AuditLog;
+import com.edu.tobserver.audit.mapper.AuditLogMapper;
+import com.edu.tobserver.common.context.LoginUser;
+import com.edu.tobserver.common.context.LoginUserContext;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuditLogService {
+
+    private final AuditLogMapper auditLogMapper;
+
+    public AuditLogService(AuditLogMapper auditLogMapper) {
+        this.auditLogMapper = auditLogMapper;
+    }
+
+    public void write(String bizType, Long bizId, String operationType, String content) {
+        LoginUser loginUser = LoginUserContext.getRequired();
+        AuditLog auditLog = new AuditLog();
+        auditLog.setBizType(bizType);
+        auditLog.setBizId(bizId);
+        auditLog.setOperationType(operationType);
+        auditLog.setOperatorId(loginUser.getUserId());
+        auditLog.setOperatorName(loginUser.getRealName());
+        auditLog.setContent(content);
+        auditLogMapper.insert(auditLog);
+    }
+}

--- a/src/main/java/com/edu/tobserver/task/controller/ObservationTaskController.java
+++ b/src/main/java/com/edu/tobserver/task/controller/ObservationTaskController.java
@@ -1,0 +1,37 @@
+package com.edu.tobserver.task.controller;
+
+import com.edu.tobserver.common.api.ApiResponse;
+import com.edu.tobserver.task.dto.TaskCreateRequest;
+import com.edu.tobserver.task.dto.TaskQueryRequest;
+import com.edu.tobserver.task.entity.ObservationTask;
+import com.edu.tobserver.task.service.ObservationTaskService;
+import com.edu.tobserver.task.vo.TaskListItemVo;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/tasks")
+public class ObservationTaskController {
+
+    private final ObservationTaskService observationTaskService;
+
+    public ObservationTaskController(ObservationTaskService observationTaskService) {
+        this.observationTaskService = observationTaskService;
+    }
+
+    @PostMapping
+    public ApiResponse<ObservationTask> create(@Valid @RequestBody TaskCreateRequest request) {
+        return ApiResponse.success(observationTaskService.create(request));
+    }
+
+    @GetMapping
+    public ApiResponse<List<TaskListItemVo>> list(@ModelAttribute TaskQueryRequest request) {
+        return ApiResponse.success(observationTaskService.list(request));
+    }
+}

--- a/src/main/java/com/edu/tobserver/task/dto/TaskCreateRequest.java
+++ b/src/main/java/com/edu/tobserver/task/dto/TaskCreateRequest.java
@@ -1,0 +1,34 @@
+package com.edu.tobserver.task.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TaskCreateRequest {
+
+    @NotBlank(message = "任务标题不能为空")
+    private String title;
+
+    @NotNull(message = "观察成员不能为空")
+    private Long observerId;
+
+    @NotBlank(message = "授课教师不能为空")
+    private String teacherName;
+
+    @NotBlank(message = "课程名称不能为空")
+    private String courseName;
+
+    @NotNull(message = "听课时间不能为空")
+    private LocalDateTime lessonTime;
+
+    @NotNull(message = "截止时间不能为空")
+    private LocalDateTime deadline;
+
+    private String remark;
+}

--- a/src/main/java/com/edu/tobserver/task/dto/TaskQueryRequest.java
+++ b/src/main/java/com/edu/tobserver/task/dto/TaskQueryRequest.java
@@ -1,0 +1,14 @@
+package com.edu.tobserver.task.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TaskQueryRequest {
+
+    private Long observerId;
+    private String status;
+}

--- a/src/main/java/com/edu/tobserver/task/entity/ObservationTask.java
+++ b/src/main/java/com/edu/tobserver/task/entity/ObservationTask.java
@@ -1,0 +1,20 @@
+package com.edu.tobserver.task.entity;
+
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class ObservationTask {
+
+    private Long id;
+    private String title;
+    private Long leaderId;
+    private Long observerId;
+    private String teacherName;
+    private String courseName;
+    private LocalDateTime lessonTime;
+    private LocalDateTime deadline;
+    private String status;
+    private String remark;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/edu/tobserver/task/mapper/ObservationTaskMapper.java
+++ b/src/main/java/com/edu/tobserver/task/mapper/ObservationTaskMapper.java
@@ -1,0 +1,55 @@
+package com.edu.tobserver.task.mapper;
+
+import com.edu.tobserver.task.entity.ObservationTask;
+import com.edu.tobserver.task.vo.TaskListItemVo;
+import java.util.List;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+
+@Mapper
+public interface ObservationTaskMapper {
+
+    @Insert("""
+            insert into observation_task
+                (title, leader_id, observer_id, teacher_name, course_name, lesson_time, deadline, status, remark)
+            values
+                (#{title}, #{leaderId}, #{observerId}, #{teacherName}, #{courseName}, #{lessonTime}, #{deadline}, #{status}, #{remark})
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "id")
+    int insert(ObservationTask observationTask);
+
+    @Select("""
+            <script>
+            select
+                t.id,
+                t.title,
+                t.observer_id,
+                observer.real_name as observer_name,
+                t.teacher_name,
+                t.course_name,
+                t.lesson_time,
+                t.deadline,
+                t.status,
+                t.remark
+            from observation_task t
+            left join sys_user observer on observer.id = t.observer_id
+            where 1 = 1
+            <if test="leaderId != null">
+                and t.leader_id = #{leaderId}
+            </if>
+            <if test="observerId != null">
+                and t.observer_id = #{observerId}
+            </if>
+            <if test="status != null and status != ''">
+                and t.status = #{status}
+            </if>
+            order by t.created_at desc, t.id desc
+            </script>
+            """)
+    List<TaskListItemVo> findList(@Param("leaderId") Long leaderId,
+                                  @Param("observerId") Long observerId,
+                                  @Param("status") String status);
+}

--- a/src/main/java/com/edu/tobserver/task/service/ObservationTaskService.java
+++ b/src/main/java/com/edu/tobserver/task/service/ObservationTaskService.java
@@ -1,0 +1,61 @@
+package com.edu.tobserver.task.service;
+
+import com.edu.tobserver.audit.service.AuditLogService;
+import com.edu.tobserver.common.context.LoginUser;
+import com.edu.tobserver.common.context.LoginUserContext;
+import com.edu.tobserver.common.enums.RoleCode;
+import com.edu.tobserver.common.enums.TaskStatus;
+import com.edu.tobserver.common.exception.BusinessException;
+import com.edu.tobserver.task.dto.TaskCreateRequest;
+import com.edu.tobserver.task.dto.TaskQueryRequest;
+import com.edu.tobserver.task.entity.ObservationTask;
+import com.edu.tobserver.task.mapper.ObservationTaskMapper;
+import com.edu.tobserver.task.vo.TaskListItemVo;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ObservationTaskService {
+
+    private final ObservationTaskMapper observationTaskMapper;
+    private final AuditLogService auditLogService;
+
+    public ObservationTaskService(ObservationTaskMapper observationTaskMapper, AuditLogService auditLogService) {
+        this.observationTaskMapper = observationTaskMapper;
+        this.auditLogService = auditLogService;
+    }
+
+    public ObservationTask create(TaskCreateRequest request) {
+        LoginUser loginUser = LoginUserContext.getRequired();
+        if (loginUser.getRoleCode() != RoleCode.LEADER) {
+            throw new BusinessException(403, "只有组长可以创建听课任务");
+        }
+
+        ObservationTask observationTask = new ObservationTask();
+        observationTask.setTitle(request.getTitle());
+        observationTask.setLeaderId(loginUser.getUserId());
+        observationTask.setObserverId(request.getObserverId());
+        observationTask.setTeacherName(request.getTeacherName());
+        observationTask.setCourseName(request.getCourseName());
+        observationTask.setLessonTime(request.getLessonTime());
+        observationTask.setDeadline(request.getDeadline());
+        observationTask.setStatus(TaskStatus.PENDING.name());
+        observationTask.setRemark(request.getRemark());
+        observationTaskMapper.insert(observationTask);
+
+        auditLogService.write("TASK", observationTask.getId(), "CREATE_TASK", "创建听课任务");
+        return observationTask;
+    }
+
+    public List<TaskListItemVo> list(TaskQueryRequest request) {
+        LoginUser loginUser = LoginUserContext.getRequired();
+        Long leaderId = null;
+        Long observerId = request.getObserverId();
+        if (loginUser.getRoleCode() == RoleCode.LEADER) {
+            leaderId = loginUser.getUserId();
+        } else if (loginUser.getRoleCode() == RoleCode.MEMBER) {
+            observerId = loginUser.getUserId();
+        }
+        return observationTaskMapper.findList(leaderId, observerId, request.getStatus());
+    }
+}

--- a/src/main/java/com/edu/tobserver/task/vo/TaskListItemVo.java
+++ b/src/main/java/com/edu/tobserver/task/vo/TaskListItemVo.java
@@ -1,0 +1,19 @@
+package com.edu.tobserver.task.vo;
+
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class TaskListItemVo {
+
+    private Long id;
+    private String title;
+    private Long observerId;
+    private String observerName;
+    private String teacherName;
+    private String courseName;
+    private LocalDateTime lessonTime;
+    private LocalDateTime deadline;
+    private String status;
+    private String remark;
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -12,3 +12,28 @@ create table if not exists evaluation_dimension (
     dimension_code varchar(64) not null unique,
     dimension_name varchar(64) not null
 );
+
+create table if not exists observation_task (
+    id bigint primary key auto_increment,
+    title varchar(128) not null,
+    leader_id bigint not null,
+    observer_id bigint not null,
+    teacher_name varchar(64) not null,
+    course_name varchar(128) not null,
+    lesson_time timestamp not null,
+    deadline timestamp not null,
+    status varchar(32) not null,
+    remark varchar(255),
+    created_at timestamp not null default current_timestamp
+);
+
+create table if not exists audit_log (
+    id bigint primary key auto_increment,
+    biz_type varchar(32) not null,
+    biz_id bigint not null,
+    operation_type varchar(32) not null,
+    operator_id bigint not null,
+    operator_name varchar(64) not null,
+    content varchar(255) not null,
+    created_at timestamp not null default current_timestamp
+);

--- a/src/test/java/com/edu/tobserver/task/ObservationTaskControllerTest.java
+++ b/src/test/java/com/edu/tobserver/task/ObservationTaskControllerTest.java
@@ -1,0 +1,99 @@
+package com.edu.tobserver.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.edu.tobserver.auth.service.TokenSessionService;
+import com.edu.tobserver.common.context.LoginUser;
+import com.edu.tobserver.common.enums.RoleCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ObservationTaskControllerTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private TokenSessionService tokenSessionService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private MockMvc mockMvc;
+
+    private String leaderToken;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+        leaderToken = tokenSessionService.create(new LoginUser(1L, "leader01", "Leader One", RoleCode.LEADER));
+    }
+
+    @Test
+    void leaderShouldCreateTaskAndWriteAuditLog() throws Exception {
+        mockMvc.perform(post("/api/tasks")
+                        .header("X-Auth-Token", leaderToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "title":"Grade 1 Math Observation",
+                                  "observerId":2,
+                                  "teacherName":"Teacher Zhao",
+                                  "courseName":"Function Concept",
+                                  "lessonTime":"2026-04-20T09:00:00",
+                                  "deadline":"2026-04-22T18:00:00",
+                                  "remark":"Focus on classroom interaction"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("PENDING"))
+                .andExpect(jsonPath("$.data.title").value("Grade 1 Math Observation"));
+
+        Integer taskCount = jdbcTemplate.queryForObject("select count(*) from observation_task", Integer.class);
+        Integer auditCount = jdbcTemplate.queryForObject("select count(*) from audit_log", Integer.class);
+
+        assertThat(taskCount).isEqualTo(1);
+        assertThat(auditCount).isEqualTo(1);
+    }
+
+    @Test
+    void leaderShouldListTasks() throws Exception {
+        jdbcTemplate.update("""
+                insert into observation_task
+                    (title, leader_id, observer_id, teacher_name, course_name, lesson_time, deadline, status, remark)
+                values
+                    (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                "Seeded Observation Task",
+                1L,
+                2L,
+                "Teacher Zhao",
+                "Function Concept",
+                java.sql.Timestamp.valueOf("2026-04-20 09:00:00"),
+                java.sql.Timestamp.valueOf("2026-04-22 18:00:00"),
+                "PENDING",
+                "Seeded for query");
+
+        mockMvc.perform(get("/api/tasks")
+                        .header("X-Auth-Token", leaderToken)
+                        .param("observerId", "2")
+                        .param("status", "PENDING"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].title").value("Seeded Observation Task"))
+                .andExpect(jsonPath("$.data[0].status").value("PENDING"));
+    }
+}


### PR DESCRIPTION
## Summary
- add Task 3 backend support for observation task creation and task listing
- add audit log persistence and service wiring for task creation events
- extend schema and add integration coverage for task creation and query flows

## Why
- Task 3 in the MVP plan requires leader task management and audit logging before record submission and review work can build on it

## Impact
- leaders can create observation tasks through /api/tasks
- authenticated users can query tasks through /api/tasks with role-aware filtering
- task creation now records an audit entry for later workflow tracking

## Validation
- .\\mvnw.cmd -Dspring.profiles.active=test -Dtest=BootstrapDataTest,AuthControllerTest,ObservationTaskControllerTest test