### PR TITLE
[codex] Task 5 add review and analytics backend

### DIFF
--- a/src/main/java/com/edu/tobserver/analytics/controller/AnalyticsController.java
+++ b/src/main/java/com/edu/tobserver/analytics/controller/AnalyticsController.java
@@ -1,0 +1,27 @@
+package com.edu.tobserver.analytics.controller;
+
+import com.edu.tobserver.analytics.dto.AnalyticsGenerateRequest;
+import com.edu.tobserver.analytics.service.AnalyticsService;
+import com.edu.tobserver.analytics.vo.AnalyticsReportVo;
+import com.edu.tobserver.common.api.ApiResponse;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/analytics")
+public class AnalyticsController {
+
+    private final AnalyticsService analyticsService;
+
+    public AnalyticsController(AnalyticsService analyticsService) {
+        this.analyticsService = analyticsService;
+    }
+
+    @PostMapping("/generate")
+    public ApiResponse<AnalyticsReportVo> generate(@Valid @RequestBody AnalyticsGenerateRequest request) {
+        return ApiResponse.success(analyticsService.generate(request));
+    }
+}

--- a/src/main/java/com/edu/tobserver/analytics/dto/AnalyticsGenerateRequest.java
+++ b/src/main/java/com/edu/tobserver/analytics/dto/AnalyticsGenerateRequest.java
@@ -1,0 +1,21 @@
+package com.edu.tobserver.analytics.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnalyticsGenerateRequest {
+
+    @NotBlank(message = "授课教师不能为空")
+    private String teacherName;
+
+    @NotBlank(message = "统计周期类型不能为空")
+    private String periodType;
+
+    @NotBlank(message = "统计周期值不能为空")
+    private String periodValue;
+}

--- a/src/main/java/com/edu/tobserver/analytics/entity/RadarReport.java
+++ b/src/main/java/com/edu/tobserver/analytics/entity/RadarReport.java
@@ -1,0 +1,19 @@
+package com.edu.tobserver.analytics.entity;
+
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class RadarReport {
+
+    private Long id;
+    private String teacherName;
+    private String periodType;
+    private String periodValue;
+    private Integer sampleCount;
+    private String radarJson;
+    private String strengthSummary;
+    private String weaknessSummary;
+    private String conclusion;
+    private LocalDateTime generatedAt;
+}

--- a/src/main/java/com/edu/tobserver/analytics/mapper/AnalyticsMapper.java
+++ b/src/main/java/com/edu/tobserver/analytics/mapper/AnalyticsMapper.java
@@ -1,0 +1,48 @@
+package com.edu.tobserver.analytics.mapper;
+
+import com.edu.tobserver.analytics.entity.RadarReport;
+import com.edu.tobserver.record.entity.ObservationRecord;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+
+@Mapper
+public interface AnalyticsMapper {
+
+    @Select("""
+            select
+                id,
+                task_id,
+                observer_id,
+                teacher_name,
+                strengths,
+                weaknesses,
+                suggestions,
+                status,
+                reject_reason,
+                submitted_at,
+                approved_at
+            from observation_record
+            where status = 'APPROVED'
+              and teacher_name = #{teacherName}
+              and approved_at >= #{startTime}
+              and approved_at < #{endTime}
+            order by approved_at desc, id desc
+            """)
+    List<ObservationRecord> findApprovedRecords(@Param("teacherName") String teacherName,
+                                                @Param("startTime") LocalDateTime startTime,
+                                                @Param("endTime") LocalDateTime endTime);
+
+    @Insert("""
+            insert into radar_report
+                (teacher_name, period_type, period_value, sample_count, radar_json, strength_summary, weakness_summary, conclusion)
+            values
+                (#{teacherName}, #{periodType}, #{periodValue}, #{sampleCount}, #{radarJson}, #{strengthSummary}, #{weaknessSummary}, #{conclusion})
+            """)
+    @Options(useGeneratedKeys = true, keyProperty = "id")
+    int insert(RadarReport radarReport);
+}

--- a/src/main/java/com/edu/tobserver/analytics/service/AnalyticsService.java
+++ b/src/main/java/com/edu/tobserver/analytics/service/AnalyticsService.java
@@ -1,0 +1,206 @@
+package com.edu.tobserver.analytics.service;
+
+import com.edu.tobserver.analytics.dto.AnalyticsGenerateRequest;
+import com.edu.tobserver.analytics.entity.RadarReport;
+import com.edu.tobserver.analytics.mapper.AnalyticsMapper;
+import com.edu.tobserver.analytics.vo.AnalyticsReportVo;
+import com.edu.tobserver.common.context.LoginUser;
+import com.edu.tobserver.common.context.LoginUserContext;
+import com.edu.tobserver.common.enums.DimensionCode;
+import com.edu.tobserver.common.enums.RoleCode;
+import com.edu.tobserver.common.exception.BusinessException;
+import com.edu.tobserver.record.entity.ObservationRecord;
+import com.edu.tobserver.record.entity.ObservationScore;
+import com.edu.tobserver.record.mapper.ObservationScoreMapper;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AnalyticsService {
+
+    private static final String LOW_SAMPLE_CONCLUSION = "样本不足，暂不生成雷达图";
+
+    private final AnalyticsMapper analyticsMapper;
+    private final ObservationScoreMapper observationScoreMapper;
+
+    public AnalyticsService(AnalyticsMapper analyticsMapper,
+                            ObservationScoreMapper observationScoreMapper) {
+        this.analyticsMapper = analyticsMapper;
+        this.observationScoreMapper = observationScoreMapper;
+    }
+
+    public AnalyticsReportVo generate(AnalyticsGenerateRequest request) {
+        requireLeader();
+        TimeRange timeRange = parseTimeRange(request.getPeriodType(), request.getPeriodValue());
+        List<ObservationRecord> approvedRecords = analyticsMapper.findApprovedRecords(
+                request.getTeacherName().trim(),
+                timeRange.startTime(),
+                timeRange.endTime());
+
+        String strengthSummary = joinTexts(approvedRecords, ObservationRecord::getStrengths);
+        String weaknessSummary = joinTexts(approvedRecords, ObservationRecord::getWeaknesses);
+
+        AnalyticsReportVo.RadarChartVo radarChart = null;
+        String conclusion;
+        if (approvedRecords.size() < 3) {
+            conclusion = LOW_SAMPLE_CONCLUSION;
+        } else {
+            radarChart = buildRadarChart(approvedRecords);
+            conclusion = "已根据 " + approvedRecords.size() + " 条已审批记录生成雷达图";
+        }
+
+        AnalyticsReportVo report = AnalyticsReportVo.builder()
+                .teacherName(request.getTeacherName().trim())
+                .periodType(request.getPeriodType().trim())
+                .periodValue(request.getPeriodValue().trim())
+                .sampleCount(approvedRecords.size())
+                .radarChart(radarChart)
+                .strengthSummary(strengthSummary)
+                .weaknessSummary(weaknessSummary)
+                .conclusion(conclusion)
+                .build();
+
+        persistReport(report);
+        return report;
+    }
+
+    private void requireLeader() {
+        LoginUser loginUser = LoginUserContext.getRequired();
+        if (loginUser.getRoleCode() != RoleCode.LEADER) {
+            throw new BusinessException(403, "只有组长可以生成教师分析");
+        }
+    }
+
+    private TimeRange parseTimeRange(String periodType, String periodValue) {
+        String normalizedType = periodType.trim().toUpperCase();
+        String normalizedValue = periodValue.trim();
+        return switch (normalizedType) {
+            case "MONTH" -> {
+                YearMonth yearMonth = YearMonth.parse(normalizedValue);
+                yield new TimeRange(yearMonth.atDay(1).atStartOfDay(), yearMonth.plusMonths(1).atDay(1).atStartOfDay());
+            }
+            case "YEAR" -> {
+                Year year = Year.parse(normalizedValue);
+                yield new TimeRange(year.atDay(1).atStartOfDay(), year.plusYears(1).atDay(1).atStartOfDay());
+            }
+            default -> throw new BusinessException(400, "统计周期类型仅支持 MONTH 或 YEAR");
+        };
+    }
+
+    private AnalyticsReportVo.RadarChartVo buildRadarChart(List<ObservationRecord> approvedRecords) {
+        Map<DimensionCode, BigDecimal> totalScores = new EnumMap<>(DimensionCode.class);
+        Map<DimensionCode, Integer> scoreCounts = new EnumMap<>(DimensionCode.class);
+        Map<DimensionCode, String> dimensionNames = new EnumMap<>(DimensionCode.class);
+
+        for (ObservationRecord approvedRecord : approvedRecords) {
+            List<ObservationScore> scores = observationScoreMapper.findByRecordId(approvedRecord.getId());
+            for (ObservationScore score : scores) {
+                DimensionCode dimensionCode = DimensionCode.valueOf(score.getDimensionCode());
+                totalScores.merge(dimensionCode, score.getScoreValue(), BigDecimal::add);
+                scoreCounts.merge(dimensionCode, 1, Integer::sum);
+                dimensionNames.putIfAbsent(dimensionCode, score.getDimensionName());
+            }
+        }
+
+        List<AnalyticsReportVo.IndicatorVo> indicators = new ArrayList<>();
+        List<BigDecimal> values = new ArrayList<>();
+        for (DimensionCode dimensionCode : DimensionCode.values()) {
+            indicators.add(AnalyticsReportVo.IndicatorVo.builder()
+                    .name(resolveDimensionName(dimensionCode, dimensionNames.get(dimensionCode)))
+                    .max(5)
+                    .build());
+            BigDecimal total = totalScores.getOrDefault(dimensionCode, BigDecimal.ZERO);
+            int count = scoreCounts.getOrDefault(dimensionCode, 0);
+            BigDecimal average = count == 0
+                    ? BigDecimal.ZERO
+                    : total.divide(BigDecimal.valueOf(count), 1, RoundingMode.HALF_UP);
+            values.add(average);
+        }
+
+        return AnalyticsReportVo.RadarChartVo.builder()
+                .indicators(indicators)
+                .values(values)
+                .build();
+    }
+
+    private String resolveDimensionName(DimensionCode dimensionCode, String configuredName) {
+        if (configuredName != null && !configuredName.isBlank()) {
+            return configuredName;
+        }
+        return switch (dimensionCode) {
+            case TEACHING_DESIGN -> "Teaching Design";
+            case CLASSROOM_ORGANIZATION -> "Classroom Organization";
+            case TEACHING_CONTENT -> "Teaching Content";
+            case INTERACTION_FEEDBACK -> "Interaction Feedback";
+            case TEACHING_EFFECTIVENESS -> "Teaching Effectiveness";
+        };
+    }
+
+    private String joinTexts(List<ObservationRecord> approvedRecords, Function<ObservationRecord, String> extractor) {
+        List<String> parts = new ArrayList<>();
+        for (ObservationRecord approvedRecord : approvedRecords) {
+            String value = extractor.apply(approvedRecord);
+            if (value != null && !value.isBlank()) {
+                parts.add(value.trim());
+            }
+        }
+        return String.join("；", parts);
+    }
+
+    private void persistReport(AnalyticsReportVo report) {
+        RadarReport radarReport = new RadarReport();
+        radarReport.setTeacherName(report.getTeacherName());
+        radarReport.setPeriodType(report.getPeriodType());
+        radarReport.setPeriodValue(report.getPeriodValue());
+        radarReport.setSampleCount(report.getSampleCount());
+        radarReport.setRadarJson(toRadarJson(report.getRadarChart()));
+        radarReport.setStrengthSummary(report.getStrengthSummary());
+        radarReport.setWeaknessSummary(report.getWeaknessSummary());
+        radarReport.setConclusion(report.getConclusion());
+        analyticsMapper.insert(radarReport);
+    }
+
+    private String toRadarJson(AnalyticsReportVo.RadarChartVo radarChart) {
+        if (radarChart == null) {
+            return null;
+        }
+        StringBuilder builder = new StringBuilder();
+        builder.append("{\"indicators\":[");
+        for (int i = 0; i < radarChart.getIndicators().size(); i++) {
+            AnalyticsReportVo.IndicatorVo indicator = radarChart.getIndicators().get(i);
+            if (i > 0) {
+                builder.append(',');
+            }
+            builder.append("{\"name\":\"")
+                    .append(escapeJson(indicator.getName()))
+                    .append("\",\"max\":")
+                    .append(indicator.getMax())
+                    .append('}');
+        }
+        builder.append("],\"values\":[");
+        for (int i = 0; i < radarChart.getValues().size(); i++) {
+            if (i > 0) {
+                builder.append(',');
+            }
+            builder.append(radarChart.getValues().get(i));
+        }
+        builder.append("]}");
+        return builder.toString();
+    }
+
+    private String escapeJson(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    private record TimeRange(LocalDateTime startTime, LocalDateTime endTime) {
+    }
+}

--- a/src/main/java/com/edu/tobserver/analytics/vo/AnalyticsReportVo.java
+++ b/src/main/java/com/edu/tobserver/analytics/vo/AnalyticsReportVo.java
@@ -1,0 +1,36 @@
+package com.edu.tobserver.analytics.vo;
+
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AnalyticsReportVo {
+
+    private final String teacherName;
+    private final String periodType;
+    private final String periodValue;
+    private final int sampleCount;
+    private final RadarChartVo radarChart;
+    private final String strengthSummary;
+    private final String weaknessSummary;
+    private final String conclusion;
+
+    @Getter
+    @Builder
+    public static class RadarChartVo {
+
+        private final List<IndicatorVo> indicators;
+        private final List<BigDecimal> values;
+    }
+
+    @Getter
+    @Builder
+    public static class IndicatorVo {
+
+        private final String name;
+        private final Integer max;
+    }
+}

--- a/src/main/java/com/edu/tobserver/record/mapper/ObservationRecordMapper.java
+++ b/src/main/java/com/edu/tobserver/record/mapper/ObservationRecordMapper.java
@@ -52,4 +52,22 @@ public interface ObservationRecordMapper {
               and observer_id = #{observerId}
             """)
     ObservationRecord findByTaskIdAndObserverId(@Param("taskId") Long taskId, @Param("observerId") Long observerId);
+
+    @Select("""
+            select
+                id,
+                task_id,
+                observer_id,
+                teacher_name,
+                strengths,
+                weaknesses,
+                suggestions,
+                status,
+                reject_reason,
+                submitted_at,
+                approved_at
+            from observation_record
+            where id = #{id}
+            """)
+    ObservationRecord findById(@Param("id") Long id);
 }

--- a/src/main/java/com/edu/tobserver/review/controller/ReviewController.java
+++ b/src/main/java/com/edu/tobserver/review/controller/ReviewController.java
@@ -1,0 +1,34 @@
+package com.edu.tobserver.review.controller;
+
+import com.edu.tobserver.common.api.ApiResponse;
+import com.edu.tobserver.record.vo.ObservationRecordVo;
+import com.edu.tobserver.review.dto.RejectRequest;
+import com.edu.tobserver.review.service.ReviewService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/reviews")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    public ReviewController(ReviewService reviewService) {
+        this.reviewService = reviewService;
+    }
+
+    @PostMapping("/{recordId}/approve")
+    public ApiResponse<ObservationRecordVo> approve(@PathVariable Long recordId) {
+        return ApiResponse.success(reviewService.approve(recordId));
+    }
+
+    @PostMapping("/{recordId}/reject")
+    public ApiResponse<ObservationRecordVo> reject(@PathVariable Long recordId,
+                                                   @Valid @RequestBody RejectRequest request) {
+        return ApiResponse.success(reviewService.reject(recordId, request.getReason()));
+    }
+}

--- a/src/main/java/com/edu/tobserver/review/dto/RejectRequest.java
+++ b/src/main/java/com/edu/tobserver/review/dto/RejectRequest.java
@@ -1,0 +1,15 @@
+package com.edu.tobserver.review.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RejectRequest {
+
+    @NotBlank(message = "退回时必须填写原因")
+    private String reason;
+}

--- a/src/main/java/com/edu/tobserver/review/service/ReviewService.java
+++ b/src/main/java/com/edu/tobserver/review/service/ReviewService.java
@@ -1,0 +1,102 @@
+package com.edu.tobserver.review.service;
+
+import com.edu.tobserver.audit.service.AuditLogService;
+import com.edu.tobserver.common.context.LoginUser;
+import com.edu.tobserver.common.context.LoginUserContext;
+import com.edu.tobserver.common.enums.RecordStatus;
+import com.edu.tobserver.common.enums.RoleCode;
+import com.edu.tobserver.common.enums.TaskStatus;
+import com.edu.tobserver.common.exception.BusinessException;
+import com.edu.tobserver.record.entity.ObservationRecord;
+import com.edu.tobserver.record.entity.ObservationScore;
+import com.edu.tobserver.record.mapper.ObservationRecordMapper;
+import com.edu.tobserver.record.mapper.ObservationScoreMapper;
+import com.edu.tobserver.record.vo.ObservationRecordVo;
+import com.edu.tobserver.task.mapper.ObservationTaskMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ReviewService {
+
+    private final ObservationRecordMapper observationRecordMapper;
+    private final ObservationScoreMapper observationScoreMapper;
+    private final ObservationTaskMapper observationTaskMapper;
+    private final AuditLogService auditLogService;
+
+    public ReviewService(ObservationRecordMapper observationRecordMapper,
+                         ObservationScoreMapper observationScoreMapper,
+                         ObservationTaskMapper observationTaskMapper,
+                         AuditLogService auditLogService) {
+        this.observationRecordMapper = observationRecordMapper;
+        this.observationScoreMapper = observationScoreMapper;
+        this.observationTaskMapper = observationTaskMapper;
+        this.auditLogService = auditLogService;
+    }
+
+    @Transactional
+    public ObservationRecordVo approve(Long recordId) {
+        requireLeader();
+        ObservationRecord observationRecord = requireSubmittedRecord(recordId);
+        observationRecord.setStatus(RecordStatus.APPROVED.name());
+        observationRecord.setRejectReason(null);
+        observationRecord.setApprovedAt(LocalDateTime.now());
+        observationRecordMapper.update(observationRecord);
+        auditLogService.write("RECORD", observationRecord.getId(), "APPROVE_RECORD", "通过听课记录");
+        return toVo(observationRecord);
+    }
+
+    @Transactional
+    public ObservationRecordVo reject(Long recordId, String reason) {
+        requireLeader();
+        if (reason == null || reason.isBlank()) {
+            throw new BusinessException(400, "退回时必须填写原因");
+        }
+        ObservationRecord observationRecord = requireSubmittedRecord(recordId);
+        observationRecord.setStatus(RecordStatus.RETURNED.name());
+        observationRecord.setRejectReason(reason.trim());
+        observationRecord.setApprovedAt(null);
+        observationRecordMapper.update(observationRecord);
+        observationTaskMapper.updateStatus(observationRecord.getTaskId(), TaskStatus.IN_PROGRESS.name());
+        auditLogService.write("RECORD", observationRecord.getId(), "REJECT_RECORD", "退回听课记录");
+        return toVo(observationRecord);
+    }
+
+    private void requireLeader() {
+        LoginUser loginUser = LoginUserContext.getRequired();
+        if (loginUser.getRoleCode() != RoleCode.LEADER) {
+            throw new BusinessException(403, "只有组长可以审核听课记录");
+        }
+    }
+
+    private ObservationRecord requireSubmittedRecord(Long recordId) {
+        ObservationRecord observationRecord = observationRecordMapper.findById(recordId);
+        if (observationRecord == null) {
+            throw new BusinessException(404, "听课记录不存在");
+        }
+        if (!RecordStatus.SUBMITTED.name().equals(observationRecord.getStatus())) {
+            throw new BusinessException(400, "只有已提交的听课记录可以审核");
+        }
+        return observationRecord;
+    }
+
+    private ObservationRecordVo toVo(ObservationRecord observationRecord) {
+        List<ObservationScore> scores = observationScoreMapper.findByRecordId(observationRecord.getId());
+        return ObservationRecordVo.builder()
+                .id(observationRecord.getId())
+                .taskId(observationRecord.getTaskId())
+                .observerId(observationRecord.getObserverId())
+                .teacherName(observationRecord.getTeacherName())
+                .strengths(observationRecord.getStrengths())
+                .weaknesses(observationRecord.getWeaknesses())
+                .suggestions(observationRecord.getSuggestions())
+                .status(observationRecord.getStatus())
+                .rejectReason(observationRecord.getRejectReason())
+                .submittedAt(observationRecord.getSubmittedAt())
+                .approvedAt(observationRecord.getApprovedAt())
+                .scores(scores)
+                .build();
+    }
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -59,3 +59,16 @@ create table if not exists observation_score (
     dimension_name varchar(64) not null,
     score_value decimal(2,1) not null
 );
+
+create table if not exists radar_report (
+    id bigint primary key auto_increment,
+    teacher_name varchar(64) not null,
+    period_type varchar(32) not null,
+    period_value varchar(32) not null,
+    sample_count int not null,
+    radar_json clob,
+    strength_summary clob not null,
+    weakness_summary clob not null,
+    conclusion varchar(255) not null,
+    generated_at timestamp not null default current_timestamp
+);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -66,9 +66,9 @@ create table if not exists radar_report (
     period_type varchar(32) not null,
     period_value varchar(32) not null,
     sample_count int not null,
-    radar_json clob,
-    strength_summary clob not null,
-    weakness_summary clob not null,
+    radar_json text,
+    strength_summary text not null,
+    weakness_summary text not null,
     conclusion varchar(255) not null,
     generated_at timestamp not null default current_timestamp
 );

--- a/src/test/java/com/edu/tobserver/review/ReviewAndAnalyticsControllerTest.java
+++ b/src/test/java/com/edu/tobserver/review/ReviewAndAnalyticsControllerTest.java
@@ -1,0 +1,149 @@
+package com.edu.tobserver.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.edu.tobserver.auth.service.TokenSessionService;
+import com.edu.tobserver.common.context.LoginUser;
+import com.edu.tobserver.common.enums.RoleCode;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ReviewAndAnalyticsControllerTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private TokenSessionService tokenSessionService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private MockMvc mockMvc;
+
+    private String leaderToken;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+        leaderToken = tokenSessionService.create(new LoginUser(1L, "leader01", "Leader One", RoleCode.LEADER));
+
+        jdbcTemplate.update("delete from observation_score");
+        jdbcTemplate.update("delete from observation_record");
+        jdbcTemplate.update("delete from observation_task");
+        jdbcTemplate.update("delete from audit_log");
+
+        jdbcTemplate.update("""
+                insert into observation_task
+                    (id, title, leader_id, observer_id, teacher_name, course_name, lesson_time, deadline, status, remark)
+                values
+                    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                1L,
+                "Grade 1 Math Observation",
+                1L,
+                2L,
+                "Teacher Zhao",
+                "Function Concept",
+                Timestamp.valueOf("2026-04-20 09:00:00"),
+                Timestamp.valueOf("2026-04-22 18:00:00"),
+                "COMPLETED",
+                "Seeded for review tests");
+
+        jdbcTemplate.update("""
+                insert into observation_record
+                    (id, task_id, observer_id, teacher_name, strengths, weaknesses, suggestions, status, reject_reason, submitted_at, approved_at)
+                values
+                    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                1L,
+                1L,
+                2L,
+                "Teacher Zhao",
+                "Good pacing",
+                "Board writing can be clearer",
+                "Add more questioning",
+                "SUBMITTED",
+                null,
+                Timestamp.valueOf("2026-04-20 10:00:00"),
+                null);
+
+        insertScore(1L, "TEACHING_DESIGN", "Teaching Design", new BigDecimal("4.5"));
+        insertScore(1L, "CLASSROOM_ORGANIZATION", "Classroom Organization", new BigDecimal("4.0"));
+        insertScore(1L, "TEACHING_CONTENT", "Teaching Content", new BigDecimal("4.2"));
+        insertScore(1L, "INTERACTION_FEEDBACK", "Interaction Feedback", new BigDecimal("4.4"));
+        insertScore(1L, "TEACHING_EFFECTIVENESS", "Teaching Effectiveness", new BigDecimal("4.3"));
+    }
+
+    @Test
+    void shouldRequireRejectReason() throws Exception {
+        mockMvc.perform(post("/api/reviews/1/reject")
+                        .header("X-Auth-Token", leaderToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"reason":""}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("退回时必须填写原因"));
+    }
+
+    @Test
+    void shouldApproveSubmittedRecord() throws Exception {
+        mockMvc.perform(post("/api/reviews/1/approve")
+                        .header("X-Auth-Token", leaderToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("APPROVED"));
+
+        String recordStatus = jdbcTemplate.queryForObject(
+                "select status from observation_record where id = 1",
+                String.class);
+        Integer auditCount = jdbcTemplate.queryForObject(
+                "select count(*) from audit_log where biz_type = 'RECORD' and operation_type = 'APPROVE_RECORD'",
+                Integer.class);
+
+        assertThat(recordStatus).isEqualTo("APPROVED");
+        assertThat(auditCount).isEqualTo(1);
+    }
+
+    @Test
+    void shouldReturnSampleInsufficientWhenApprovedRecordsLessThanThree() throws Exception {
+        mockMvc.perform(post("/api/analytics/generate")
+                        .header("X-Auth-Token", leaderToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"teacherName":"Teacher Zhao","periodType":"MONTH","periodValue":"2026-04"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.sampleCount").value(0))
+                .andExpect(jsonPath("$.data.radarChart").doesNotExist())
+                .andExpect(jsonPath("$.data.conclusion").value("样本不足，暂不生成雷达图"));
+    }
+
+    private void insertScore(Long recordId, String dimensionCode, String dimensionName, BigDecimal scoreValue) {
+        jdbcTemplate.update("""
+                insert into observation_score
+                    (record_id, dimension_code, dimension_name, score_value)
+                values
+                    (?, ?, ?, ?)
+                """,
+                recordId,
+                dimensionCode,
+                dimensionName,
+                scoreValue);
+    }
+}

--- a/src/test/java/com/edu/tobserver/task/ObservationTaskControllerTest.java
+++ b/src/test/java/com/edu/tobserver/task/ObservationTaskControllerTest.java
@@ -41,6 +41,8 @@ class ObservationTaskControllerTest {
     void setUp() {
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
         leaderToken = tokenSessionService.create(new LoginUser(1L, "leader01", "Leader One", RoleCode.LEADER));
+        jdbcTemplate.update("delete from audit_log");
+        jdbcTemplate.update("delete from observation_task");
     }
 
     @Test


### PR DESCRIPTION
## What changed
- add leader review approve/reject endpoints and validation for reject reasons
- add analytics generation endpoints, report persistence, and low-sample handling
- extend backend tests for review/analytics flows and fix task controller test isolation

## Why
Task 5 in the MVP plan requires the backend review flow and analytics generation before the frontend pages can be wired.

## Impact
Leaders can now approve or reject submitted observation records, and analytics requests can return text-only summaries when approved samples are insufficient.

## Validation
- & .\\mvnw.cmd '-Dspring.profiles.active=test' '-Dtest=ReviewAndAnalyticsControllerTest' test
- & .\\mvnw.cmd '-Dspring.profiles.active=test' test