### PR TITLE
[codex]  task7 implement task list and record frontend

### DIFF
--- a/doc/superpowers/specs/2026-04-20-task7-task-list-and-record-form-design.md
+++ b/doc/superpowers/specs/2026-04-20-task7-task-list-and-record-form-design.md
@@ -1,0 +1,774 @@
+# Task 7 任务列表与听课记录表单前端设计
+
+## 范围
+
+本设计文档覆盖 MVP 计划中的 Task 7，对应 GitHub issue `MVP Task 7: Build Task List and Record Form Frontend #8`。
+
+本次设计只覆盖以下前端范围：
+
+- 成员任务列表页 `t-observer-web/src/views/member/MemberTaskListView.vue`
+- 听课记录填写页 `t-observer-web/src/views/member/RecordFormView.vue`
+- 组长任务管理页 `t-observer-web/src/views/leader/LeaderTaskManageView.vue`
+- 任务与记录 API 模块
+- 任务与记录类型定义
+- 任务状态标签组件
+- 五维评分面板组件
+- 路由接入与主导航调整
+- Task 7 最小测试与构建验证方案
+
+本次设计不包含以下内容：
+
+- 后端接口扩展
+- 成员选择下拉接口
+- 听课记录详情查询接口
+- 组长审核页
+- 分析雷达图页
+- 登录与鉴权架构调整
+
+## 目标
+
+- 让成员登录后能够查看自己被分配的听课任务。
+- 让成员按任务状态筛选任务，并进入独立页面填写听课记录。
+- 让成员可以保存草稿，并在满足校验条件后正式提交记录。
+- 让组长在同一页面查看自己创建的任务，并通过抽屉快速创建新任务。
+- 在不改变后端契约的前提下，把 Task 7 细化到可直接实施的程度，包括接口字段、页面状态、异常态与测试边界。
+
+## 当前项目基线
+
+当前仓库已经具备以下前置基础，可作为 Task 7 的直接承接点：
+
+- 后端已存在认证、任务、记录、审核、分析模块。
+- 后端已提供以下接口：
+  - `GET /api/tasks`
+  - `POST /api/tasks`
+  - `POST /api/records/save-draft`
+  - `POST /api/records/submit`
+- 前端已完成 Task 6 的基础工作：
+  - 登录页
+  - 主布局 `MainLayout.vue`
+  - 认证 store
+  - 路由守卫
+  - HTTP 客户端
+  - 主题变量 `src/styles/ui-theme.css`
+
+Task 7 应在这个现有基础上增量扩展，不替换 Task 6 已经建立的视觉风格、认证方式或主布局结构。
+
+## 已确认的产品决策
+
+- 范围以 MVP 计划文档中的 Task 7 为准，不延伸到 Task 8。
+- 设计深度采用“可直接实施”标准，可以补全接口字段、交互状态、空态和异常态，但不改架构和后端契约。
+- `LeaderTaskManageView` 采用“同页管理 + 抽屉创建任务”的方案。
+- 成员端采用“任务列表页 + 独立记录填写页”的方案，不使用弹窗承载记录表单。
+- 设计文档使用中文书写。
+
+## 设计方案对比
+
+### 方案 A：成员列表页内弹窗填写记录，组长页抽屉创建
+
+优点：
+
+- 路径最短
+- 所有任务操作都停留在列表页
+
+缺点：
+
+- 听课记录表单字段较多，包含五维评分和三段文本，弹窗承载会明显拥挤
+- 移动端体验较差
+- 草稿与提交状态提示容易与列表上下文混在一起
+
+### 方案 B：成员任务列表页 + 独立记录填写页，组长页抽屉创建
+
+优点：
+
+- 信息层级清晰，符合当前 MVP 复杂度
+- 听课记录页可以完整展示任务摘要、评分区和文本区
+- 桌面端和移动端都更容易做好可读性和可操作性
+- 组长创建任务继续保持高效的同页抽屉流程
+
+缺点：
+
+- 成员填写记录需要多一次页面跳转
+
+### 方案 C：统一任务中心页，按角色切换内容
+
+优点：
+
+- 路由数量少
+- 看起来功能集中
+
+缺点：
+
+- 角色判断复杂
+- 页面分支和条件渲染明显增多
+- 不适合当前 MVP 的单任务渐进实现节奏
+
+### 选型结论
+
+采用方案 B：
+
+- 成员端使用任务列表页和独立记录填写页
+- 组长端使用任务管理页和抽屉创建
+
+这个方案最符合当前 Task 7 的实际边界，也与现有主布局、路由结构和后端能力匹配。
+
+## 视觉与交互方向
+
+Task 7 延续 Task 6 已确认的前端设计基线：
+
+- 主色使用 `#409EFF`
+- 内容区背景使用 `#f5f7fa`
+- 卡片、按钮、输入框等组件保持 `8px` 圆角基线
+- 字体沿用系统默认无衬线栈
+- 标题约 `18px`
+- 正文约 `14px`
+- 保持轻量、通透、蓝色主导的后台风格
+- 复用 `t-observer-web/src/styles/ui-theme.css` 中已有设计变量
+
+Task 7 页面新增的视觉要求如下：
+
+- 成员任务列表优先使用卡片而不是密集表格，保证移动端可读性
+- 组长任务管理桌面端使用轻表格，移动端退化为卡片
+- 状态筛选区要足够清晰，但不使用厚重的分段控件边框
+- 记录填写页要突出任务摘要和评分结构，避免长表单造成阅读疲劳
+
+## 页面信息架构
+
+### 1. 成员任务列表页 `MemberTaskListView`
+
+页面目标：
+
+- 展示当前成员自己的听课任务
+- 提供状态筛选
+- 提供进入记录填写页的入口
+
+页面结构：
+
+- 顶部标题区
+  - 页面标题
+  - 简短副标题
+  - 当前角色提示
+- 状态筛选区
+  - `全部`
+  - `待填写`
+  - `进行中`
+  - `已完成`
+- 列表区
+  - 任务卡片列表
+- 空态区
+  - 当前筛选结果为空时展示
+- 错误态区
+  - 首次加载失败时展示重试入口
+
+任务卡片字段：
+
+- `title`
+- `teacherName`
+- `courseName`
+- `lessonTime`
+- `deadline`
+- `remark`
+- `status`
+
+任务卡片主操作：
+
+- `PENDING`：显示“填写记录”
+- `IN_PROGRESS`：显示“继续填写”
+- `COMPLETED`：显示“查看记录”
+
+交互规则：
+
+- 成员端不显示 `observerId` 筛选能力
+- 切换状态筛选时重新请求任务列表
+- 点击任务操作按钮时跳转到 `/member/tasks/:taskId/record`
+- 路由跳转时带上任务摘要信息，减少记录页首屏依赖
+
+### 2. 听课记录填写页 `RecordFormView`
+
+页面目标：
+
+- 承载一次完整的听课记录填写
+- 支持草稿保存
+- 支持正式提交
+
+页面结构：
+
+- 顶部返回区
+  - 返回任务列表按钮
+  - 页面标题
+  - 当前任务状态摘要
+- 任务信息卡
+  - 任务标题
+  - 授课教师
+  - 课程名称
+  - 听课时间
+  - 截止时间
+  - 备注
+- 五维评分区
+  - 复用 `DimensionScorePanel`
+- 文本填写区
+  - 优点分析
+  - 待改进项
+  - 改进建议
+- 底部操作区
+  - 保存草稿
+  - 提交记录
+  - 提示文案
+
+字段组织规则：
+
+- 五个维度评分固定展示在文本区前面
+- `teacherName` 在页面中只展示，不允许用户修改
+- 三个文本域都使用较高的输入框，便于中等长度内容录入
+- 每个文本域提供简洁的中文占位提示
+
+### 3. 组长任务管理页 `LeaderTaskManageView`
+
+页面目标：
+
+- 展示当前组长创建的任务
+- 在同一页面通过抽屉创建新任务
+
+页面结构：
+
+- 顶部标题区
+  - 页面标题
+  - 简短副标题
+  - “新建任务”主按钮
+- 筛选区
+  - 状态筛选
+- 列表区
+  - 桌面端轻表格
+  - 移动端卡片
+- 新建任务抽屉
+  - 任务标题
+  - 听课成员 ID
+  - 授课教师
+  - 课程名称
+  - 听课时间
+  - 截止时间
+  - 备注
+  - 取消与提交按钮
+
+交互规则：
+
+- 点击“新建任务”后从右侧打开抽屉
+- 创建成功后关闭抽屉并刷新列表
+- 创建失败时保留用户输入内容
+
+## 共用组件设计
+
+### `src/components/common/StatusTag.vue`
+
+职责：
+
+- 接收任务状态码
+- 输出统一的中文文案和视觉样式
+
+覆盖状态：
+
+- `PENDING`
+- `IN_PROGRESS`
+- `COMPLETED`
+
+中文映射：
+
+- `PENDING` -> `待填写`
+- `IN_PROGRESS` -> `进行中`
+- `COMPLETED` -> `已完成`
+
+视觉建议：
+
+- `PENDING`：浅橙底色
+- `IN_PROGRESS`：浅蓝底色
+- `COMPLETED`：浅绿底色
+
+组件边界：
+
+- 只负责状态展示
+- 不承担业务判断和跳转逻辑
+
+### `src/components/record/DimensionScorePanel.vue`
+
+职责：
+
+- 承载五个固定维度的评分输入
+- 通过 `v-model` 与页面双向绑定
+
+固定维度顺序：
+
+- `TEACHING_DESIGN`
+- `CLASSROOM_ORGANIZATION`
+- `TEACHING_CONTENT`
+- `INTERACTION_FEEDBACK`
+- `TEACHING_EFFECTIVENESS`
+
+中文名称映射：
+
+- `TEACHING_DESIGN` -> `教学设计`
+- `CLASSROOM_ORGANIZATION` -> `课堂组织`
+- `TEACHING_CONTENT` -> `教学内容`
+- `INTERACTION_FEEDBACK` -> `互动反馈`
+- `TEACHING_EFFECTIVENESS` -> `教学效果`
+
+交互要求：
+
+- 支持首次空值初始化
+- 支持草稿回填
+- 每一行展示维度名称、评分控件、当前分值
+- 组件内部不直接提交校验错误，只提供数据结构和基础输入约束
+
+推荐控件：
+
+- 使用 Element Plus `el-input-number` 或 `el-slider`
+- 评分粒度保留一位小数
+- 最小值 `1.0`
+- 最大值 `5.0`
+- 步长 `0.5`
+
+说明：
+
+后端只校验分数位于 `1.0` 到 `5.0` 范围内，没有规定必须是 `0.5` 的倍数。前端使用 `0.5` 步长是为了简化 MVP 交互，并保持评分选择稳定。
+
+## 路由与导航设计
+
+建议新增和调整以下路由：
+
+- `/member/tasks`
+- `/member/tasks/:taskId/record`
+- `/leader/tasks`
+
+导航策略：
+
+- 侧边栏继续保留一个统一入口“任务”
+- 成员登录后默认进入 `/member/tasks`
+- 组长登录后默认进入 `/leader/tasks`
+
+兼容策略：
+
+- 当前存在的 `/tasks`、`/records` 预览路由不应继续作为真实业务入口
+- 可以移除占位组件，或将其重定向到角色对应的任务页
+
+推荐做法：
+
+- `/tasks` 根据当前角色重定向：
+  - `MEMBER` -> `/member/tasks`
+  - `LEADER` -> `/leader/tasks`
+- `/records` 不再作为一级导航入口，避免与记录填写详情页的概念冲突
+
+## 前端类型设计
+
+### `src/types/task.ts`
+
+建议定义：
+
+- `TaskStatus = 'PENDING' | 'IN_PROGRESS' | 'COMPLETED'`
+- `TaskListItem`
+  - `id: number`
+  - `title: string`
+  - `observerId: number`
+  - `observerName: string`
+  - `teacherName: string`
+  - `courseName: string`
+  - `lessonTime: string`
+  - `deadline: string`
+  - `status: TaskStatus`
+  - `remark: string | null`
+- `TaskQueryParams`
+  - `status?: TaskStatus`
+- `TaskCreatePayload`
+  - `title: string`
+  - `observerId: number`
+  - `teacherName: string`
+  - `courseName: string`
+  - `lessonTime: string`
+  - `deadline: string`
+  - `remark?: string`
+
+说明：
+
+- 后端返回时间字段为 `LocalDateTime`，前端统一以字符串处理，并在页面层格式化展示
+- 成员端不需要暴露 `observerId` 查询参数
+- 组长创建任务仍使用 `observerId` 数值输入，因为当前后端未提供成员列表接口
+
+### `src/types/record.ts`
+
+建议定义：
+
+- `DimensionCode`
+  - `TEACHING_DESIGN`
+  - `CLASSROOM_ORGANIZATION`
+  - `TEACHING_CONTENT`
+  - `INTERACTION_FEEDBACK`
+  - `TEACHING_EFFECTIVENESS`
+- `ScoreItem`
+  - `dimensionCode: DimensionCode`
+  - `dimensionName: string`
+  - `scoreValue: number | null`
+- `RecordDraftPayload`
+  - `taskId: number`
+  - `teacherName: string`
+  - `strengths: string`
+  - `weaknesses: string`
+  - `suggestions: string`
+  - `scores: ScoreItem[]`
+- `RecordSubmitPayload`
+  - 与 `RecordDraftPayload` 相同
+- `ObservationRecord`
+  - `id: number`
+  - `taskId: number`
+  - `observerId: number`
+  - `teacherName: string`
+  - `strengths: string`
+  - `weaknesses: string`
+  - `suggestions: string`
+  - `status: string`
+  - `rejectReason: string | null`
+  - `submittedAt: string | null`
+  - `approvedAt: string | null`
+  - `scores: ScoreItem[]`
+
+说明：
+
+- 草稿结构与提交结构保持一致，降低页面层分叉
+- 草稿允许文本为空和评分不完整
+- 提交前由前端执行完整性校验
+
+## API 契约设计
+
+前端继续沿用当前 `ApiEnvelope<T>` 解包模式，页面层只接收 `data.data`。
+
+### `src/api/tasks.ts`
+
+提供：
+
+- `fetchTasks(params?: TaskQueryParams)`
+  - 请求 `GET /tasks`
+  - 返回 `TaskListItem[]`
+- `createTask(payload: TaskCreatePayload)`
+  - 请求 `POST /tasks`
+  - 返回创建后的任务对象
+
+接口约束：
+
+- `fetchTasks` 只接受可选状态筛选
+- `createTask` 不封装额外转换逻辑，直接按后端契约提交
+
+### `src/api/records.ts`
+
+提供：
+
+- `saveRecordDraft(payload: RecordDraftPayload)`
+  - 请求 `POST /records/save-draft`
+  - 返回 `ObservationRecord`
+- `submitRecord(payload: RecordSubmitPayload)`
+  - 请求 `POST /records/submit`
+  - 返回 `ObservationRecord`
+
+接口约束：
+
+- 不新增记录详情查询函数
+- 记录页的首屏数据依赖路由上下文而不是额外接口
+
+## 页面状态机与交互细节
+
+### 成员任务列表页状态机
+
+状态：
+
+- 初始态
+- 加载态
+- 成功态
+- 空态
+- 失败态
+
+流程：
+
+1. 页面进入后立即拉取任务列表
+2. 请求中展示骨架卡片
+3. 请求成功：
+   - 有数据则展示任务卡片
+   - 无数据则展示空态
+4. 请求失败展示错误态和重试按钮
+5. 切换状态筛选时重新拉取列表
+
+成员页约束：
+
+- 前端不显示他人任务筛选
+- 不显示新建任务按钮
+- 只保留和自身任务填写相关的主操作
+
+### 记录填写页状态机
+
+本地状态：
+
+- `taskInfo`
+- `scores`
+- `strengths`
+- `weaknesses`
+- `suggestions`
+- `isSavingDraft`
+- `isSubmitting`
+
+进入方式：
+
+- 从成员任务列表点击进入
+- 通过路由参数携带 `taskId`
+- 通过路由 `query` 或导航状态携带任务摘要
+
+如果缺少任务上下文：
+
+- 页面展示错误态卡片
+- 引导用户返回任务列表重新进入
+
+草稿保存流程：
+
+1. 用户点击“保存草稿”
+2. 不做完整性强校验
+3. 调用 `saveRecordDraft`
+4. 成功后提示“草稿已保存”
+5. 页面保持停留，继续编辑
+
+正式提交流程：
+
+1. 用户点击“提交记录”
+2. 前端执行完整性校验
+3. 弹出二次确认
+4. 调用 `submitRecord`
+5. 成功后提示“记录已提交”
+6. 返回成员任务列表并刷新
+
+提交前校验规则：
+
+- `strengths` 非空
+- `weaknesses` 非空
+- `suggestions` 非空
+- 评分数量为 5
+- 五个维度必须齐全且不能重复
+- 每项评分必须处于 `1.0 ~ 5.0`
+
+已完成任务策略：
+
+- 当任务状态为 `COMPLETED` 时，记录页进入只读展示模式
+- 隐藏或禁用“提交记录”
+- 隐藏或禁用“保存草稿”
+
+原因：
+
+- 当前后端允许更新已存在记录
+- 如果前端继续放开编辑，会与“已完成”的用户认知冲突
+- MVP 阶段以前端只读收口更稳妥
+
+### 组长任务管理页状态机
+
+状态：
+
+- 列表初始态
+- 列表加载态
+- 列表成功态
+- 列表空态
+- 列表失败态
+- 抽屉关闭态
+- 抽屉打开态
+- 创建中
+
+创建流程：
+
+1. 点击“新建任务”
+2. 打开抽屉并初始化空表单
+3. 用户填写表单
+4. 前端做字段必填校验
+5. 前端做时间顺序校验
+6. 调用 `createTask`
+7. 成功后关闭抽屉、重置表单并刷新列表
+8. 失败时保留用户输入并展示错误提示
+
+时间校验规则：
+
+- 截止时间不能早于听课时间
+
+## 文案与异常态设计
+
+### 成员任务列表空态
+
+- 标题：`暂无听课任务`
+- 说明：`当前筛选条件下没有待处理任务，可稍后刷新查看。`
+
+### 组长任务列表空态
+
+- 标题：`暂无已创建任务`
+- 说明：`可以先创建一条听课任务，分配给成员开始填写记录。`
+
+### 记录页上下文缺失异常态
+
+- 标题：`未找到任务信息`
+- 说明：`请从任务列表重新进入该记录页面。`
+- 操作按钮：`返回任务列表`
+
+### 统一错误提示策略
+
+- 草稿保存失败：
+  - `草稿保存失败，请稍后重试`
+- 提交失败：
+  - 优先展示后端 message
+  - 否则兜底为 `提交失败，请检查填写内容后重试`
+- 创建任务失败：
+  - 优先展示后端 message
+  - 否则兜底为 `任务创建失败，请稍后重试`
+
+### 状态文案统一
+
+- `PENDING` -> `待填写`
+- `IN_PROGRESS` -> `进行中`
+- `COMPLETED` -> `已完成`
+
+## 表单与校验设计
+
+### 组长创建任务表单
+
+字段：
+
+- 任务标题
+- 听课成员 ID
+- 授课教师
+- 课程名称
+- 听课时间
+- 截止时间
+- 备注
+
+校验：
+
+- 标题必填
+- 听课成员 ID 必填且必须是数字
+- 授课教师必填
+- 课程名称必填
+- 听课时间必填
+- 截止时间必填
+- 截止时间不能早于听课时间
+
+因为当前没有成员列表接口，`observerId` 使用数字输入框或普通文本框加数字校验，并在表单提示中说明示例格式。
+
+### 听课记录表单
+
+字段：
+
+- 五个维度评分
+- 优点分析
+- 待改进项
+- 改进建议
+
+草稿保存：
+
+- 允许为空
+- 允许评分不完整
+
+正式提交：
+
+- 三段文本均必填
+- 五个维度评分必须完整
+- 每项评分必须合法
+
+## 文件职责划分
+
+### 新增文件
+
+- `t-observer-web/src/types/task.ts`
+- `t-observer-web/src/types/record.ts`
+- `t-observer-web/src/api/tasks.ts`
+- `t-observer-web/src/api/records.ts`
+- `t-observer-web/src/components/common/StatusTag.vue`
+- `t-observer-web/src/components/record/DimensionScorePanel.vue`
+- `t-observer-web/src/views/member/MemberTaskListView.vue`
+- `t-observer-web/src/views/member/RecordFormView.vue`
+- `t-observer-web/src/views/leader/LeaderTaskManageView.vue`
+- `t-observer-web/src/views/member/MemberTaskListView.spec.ts`
+
+### 修改文件
+
+- `t-observer-web/src/router/index.ts`
+
+### 文件职责说明
+
+- `task.ts`
+  - 承载任务相关类型
+- `record.ts`
+  - 承载记录、评分与维度相关类型
+- `tasks.ts`
+  - 封装任务接口请求
+- `records.ts`
+  - 封装记录接口请求
+- `StatusTag.vue`
+  - 统一状态文案与色彩表达
+- `DimensionScorePanel.vue`
+  - 统一五维评分录入方式
+- `MemberTaskListView.vue`
+  - 成员任务筛选与列表展示
+- `RecordFormView.vue`
+  - 成员听课记录填写和提交
+- `LeaderTaskManageView.vue`
+  - 组长任务列表与创建抽屉
+- `router/index.ts`
+  - 角色对应路由和导航重定向逻辑
+
+## 测试与验收策略
+
+Task 7 计划文档要求的最小验证集为：
+
+- `npx vitest run src/views/member/MemberTaskListView.spec.ts`
+- `npm run type-check`
+- `npm run build`
+
+为了把实现风险降到可接受范围，建议按以下层级补充前端验证。
+
+### 必做测试
+
+`src/views/member/MemberTaskListView.spec.ts`
+
+至少覆盖：
+
+- 能渲染状态筛选项
+- 能渲染任务卡片关键信息
+- 不同状态展示正确操作文案
+- 无数据时显示空态
+
+### 建议补充测试
+
+- `StatusTag.spec.ts`
+  - 不同状态映射到正确中文文案
+- `DimensionScorePanel.spec.ts`
+  - 初始化五个维度
+  - 修改评分时触发 `update:modelValue`
+- `LeaderTaskManageView.spec.ts`
+  - 点击按钮打开抽屉
+  - 校验失败时不提交
+- `RecordFormView.spec.ts`
+  - 提交时缺少内容会提示校验错误
+  - 草稿保存入口能触发对应调用
+
+### 构建验收建议
+
+- `cd t-observer-web`
+- `npx vitest run src/views/member/MemberTaskListView.spec.ts`
+- 如有新增 spec，再按文件补跑
+- `npm run type-check`
+- `npm run build`
+
+## 风险与约束
+
+- 不新增后端接口，避免偏离 Task 7 范围
+- 不改动现有登录、鉴权和主布局主结构
+- 不引入成员下拉选择数据源，组长创建任务先使用 `observerId`
+- 不把 `/records` 继续保留为和记录填写页并列的一级业务入口
+- 不在不同页面重复维护状态中文映射和维度中文映射，必须集中复用
+- 不在已完成任务上继续开放可编辑提交，避免与状态认知冲突
+
+## 实施结论
+
+Task 7 的推荐实施方向如下：
+
+- 成员端：任务列表页 + 独立记录填写页
+- 组长端：任务管理页 + 同页抽屉创建
+- 共用层：状态标签与五维评分组件
+- 路由层：按角色收敛到真实任务页，移除占位页歧义
+- 数据层：严格复用现有任务与记录接口，不扩后端
+
+这个设计能够在不改变既有架构的前提下，把 Task 7 收敛成一组可直接实施、可测试、可 review 的前端改动。

--- a/src/main/java/com/edu/tobserver/auth/controller/AuthController.java
+++ b/src/main/java/com/edu/tobserver/auth/controller/AuthController.java
@@ -6,10 +6,12 @@ import com.edu.tobserver.auth.vo.CurrentUserVo;
 import com.edu.tobserver.auth.vo.LoginResponse;
 import com.edu.tobserver.common.api.ApiResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -30,5 +32,10 @@ public class AuthController {
     @GetMapping("/me")
     public ApiResponse<CurrentUserVo> currentUser() {
         return ApiResponse.success(authService.currentUser());
+    }
+
+    @GetMapping("/members")
+    public ApiResponse<List<CurrentUserVo>> listMembers(@RequestParam(required = false) String keyword) {
+        return ApiResponse.success(authService.listMembers(keyword));
     }
 }

--- a/src/main/java/com/edu/tobserver/auth/mapper/UserMapper.java
+++ b/src/main/java/com/edu/tobserver/auth/mapper/UserMapper.java
@@ -1,7 +1,9 @@
 package com.edu.tobserver.auth.mapper;
 
 import com.edu.tobserver.auth.entity.SysUser;
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
 
 @Mapper
@@ -13,4 +15,18 @@ public interface UserMapper {
             where username = #{username}
             """)
     SysUser findByUsername(String username);
+
+    @Select("""
+            <script>
+            select id, username, password, real_name, role_code, status
+            from sys_user
+            where role_code = 'MEMBER'
+              and status = 'ACTIVE'
+            <if test="keyword != null and keyword != ''">
+              and real_name like concat('%', #{keyword}, '%')
+            </if>
+            order by real_name asc, id asc
+            </script>
+            """)
+    List<SysUser> findActiveMembers(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/edu/tobserver/auth/service/AuthService.java
+++ b/src/main/java/com/edu/tobserver/auth/service/AuthService.java
@@ -7,7 +7,9 @@ import com.edu.tobserver.auth.vo.CurrentUserVo;
 import com.edu.tobserver.auth.vo.LoginResponse;
 import com.edu.tobserver.common.context.LoginUser;
 import com.edu.tobserver.common.context.LoginUserContext;
+import com.edu.tobserver.common.enums.RoleCode;
 import com.edu.tobserver.common.exception.BusinessException;
+import java.util.List;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -50,5 +52,21 @@ public class AuthService {
                 .realName(loginUser.getRealName())
                 .roleCode(loginUser.getRoleCode())
                 .build();
+    }
+
+    public List<CurrentUserVo> listMembers(String keyword) {
+        LoginUser loginUser = LoginUserContext.getRequired();
+        if (loginUser.getRoleCode() != RoleCode.LEADER && loginUser.getRoleCode() != RoleCode.ADMIN) {
+            throw new BusinessException(403, "只有组长或管理员可以查看成员列表");
+        }
+
+        return userMapper.findActiveMembers(keyword == null ? null : keyword.trim()).stream()
+                .map(user -> CurrentUserVo.builder()
+                        .userId(user.getId())
+                        .username(user.getUsername())
+                        .realName(user.getRealName())
+                        .roleCode(user.getRoleCode())
+                        .build())
+                .toList();
     }
 }

--- a/src/main/java/com/edu/tobserver/record/controller/ObservationRecordController.java
+++ b/src/main/java/com/edu/tobserver/record/controller/ObservationRecordController.java
@@ -6,6 +6,8 @@ import com.edu.tobserver.record.dto.RecordSubmitRequest;
 import com.edu.tobserver.record.service.ObservationRecordService;
 import com.edu.tobserver.record.vo.ObservationRecordVo;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,5 +31,10 @@ public class ObservationRecordController {
     @PostMapping("/submit")
     public ApiResponse<ObservationRecordVo> submit(@Valid @RequestBody RecordSubmitRequest request) {
         return ApiResponse.success(observationRecordService.submit(request));
+    }
+
+    @GetMapping("/task/{taskId}")
+    public ApiResponse<ObservationRecordVo> currentByTask(@PathVariable Long taskId) {
+        return ApiResponse.success(observationRecordService.findCurrentByTaskId(taskId));
     }
 }

--- a/src/main/java/com/edu/tobserver/record/service/ObservationRecordService.java
+++ b/src/main/java/com/edu/tobserver/record/service/ObservationRecordService.java
@@ -95,6 +95,23 @@ public class ObservationRecordService {
         return toVo(savedRecord);
     }
 
+    public ObservationRecordVo findCurrentByTaskId(Long taskId) {
+        LoginUser loginUser = requireMember();
+        ObservationTask observationTask = observationTaskMapper.findById(taskId);
+        if (observationTask == null) {
+            throw new BusinessException(404, "\u542c\u8bfe\u4efb\u52a1\u4e0d\u5b58\u5728");
+        }
+        if (!loginUser.getUserId().equals(observationTask.getObserverId())) {
+            throw new BusinessException(403, "\u4f60\u65e0\u6743\u67e5\u770b\u8be5\u4efb\u52a1\u7684\u542c\u8bfe\u8bb0\u5f55");
+        }
+
+        ObservationRecord observationRecord = observationRecordMapper.findByTaskIdAndObserverId(taskId, loginUser.getUserId());
+        if (observationRecord == null) {
+            return null;
+        }
+        return toVo(observationRecord);
+    }
+
     private LoginUser requireMember() {
         LoginUser loginUser = LoginUserContext.getRequired();
         if (loginUser.getRoleCode() != RoleCode.MEMBER) {

--- a/src/test/java/com/edu/tobserver/auth/AuthControllerTest.java
+++ b/src/test/java/com/edu/tobserver/auth/AuthControllerTest.java
@@ -5,6 +5,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.edu.tobserver.auth.service.TokenSessionService;
+import com.edu.tobserver.common.context.LoginUser;
+import com.edu.tobserver.common.enums.RoleCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,11 +25,16 @@ class AuthControllerTest {
     @Autowired
     private WebApplicationContext webApplicationContext;
 
+    @Autowired
+    private TokenSessionService tokenSessionService;
+
     private MockMvc mockMvc;
+    private String leaderToken;
 
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+        leaderToken = tokenSessionService.create(new LoginUser(1L, "leader01", "Leader One", RoleCode.LEADER));
     }
 
     @Test
@@ -46,5 +54,14 @@ class AuthControllerTest {
         mockMvc.perform(get("/api/auth/me"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.message").value("未登录或登录已过期"));
+    }
+
+    @Test
+    void shouldListActiveMembersForTaskAssignment() throws Exception {
+        mockMvc.perform(get("/api/auth/members")
+                        .header("X-Auth-Token", leaderToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].realName").isNotEmpty())
+                .andExpect(jsonPath("$.data[0].roleCode").value("MEMBER"));
     }
 }

--- a/src/test/java/com/edu/tobserver/record/ObservationRecordControllerTest.java
+++ b/src/test/java/com/edu/tobserver/record/ObservationRecordControllerTest.java
@@ -1,13 +1,14 @@
 package com.edu.tobserver.record;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.edu.tobserver.auth.service.TokenSessionService;
 import com.edu.tobserver.common.context.LoginUser;
 import com.edu.tobserver.common.enums.RoleCode;
-import com.edu.tobserver.auth.service.TokenSessionService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -79,7 +80,7 @@ class ObservationRecordControllerTest {
                                 }
                                 """))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("\u63d0\u4ea4\u65f6\u5fc5\u987b\u586b\u5199 5 \u4e2a\u7ef4\u5ea6\u8bc4\u5206"));
+                .andExpect(jsonPath("$.message").value("提交时必须填写 5 个维度评分"));
     }
 
     @Test
@@ -140,5 +141,32 @@ class ObservationRecordControllerTest {
         assertThat(recordCount).isEqualTo(1);
         assertThat(scoreCount).isEqualTo(5);
         assertThat(taskStatus).isEqualTo("COMPLETED");
+    }
+
+    @Test
+    void shouldReturnExistingRecordByTaskId() throws Exception {
+        mockMvc.perform(post("/api/records/save-draft")
+                        .header("X-Auth-Token", memberToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "taskId":1,
+                                  "teacherName":"Teacher Zhao",
+                                  "strengths":"Classroom rhythm is good",
+                                  "weaknesses":"Board writing can be clearer",
+                                  "suggestions":"Add more in-class follow-up questions",
+                                  "scores":[
+                                    {"dimensionCode":"TEACHING_DESIGN","scoreValue":4.5}
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/records/task/1")
+                        .header("X-Auth-Token", memberToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.taskId").value(1))
+                .andExpect(jsonPath("$.data.status").value("DRAFT"))
+                .andExpect(jsonPath("$.data.strengths").value("Classroom rhythm is good"));
     }
 }

--- a/t-observer-web/src/api/auth.ts
+++ b/t-observer-web/src/api/auth.ts
@@ -3,6 +3,7 @@ import type {
   CurrentUserResponse,
   LoginRequest,
   LoginResponse,
+  MemberOption,
 } from '@/types/auth'
 
 import { http } from './http'
@@ -14,5 +15,12 @@ export async function login(payload: LoginRequest) {
 
 export async function fetchCurrentUser() {
   const response = await http.get<ApiEnvelope<CurrentUserResponse>>('/auth/me')
+  return response.data.data
+}
+
+export async function fetchMembers(keyword?: string) {
+  const response = await http.get<ApiEnvelope<MemberOption[]>>('/auth/members', {
+    params: keyword ? { keyword } : undefined,
+  })
   return response.data.data
 }

--- a/t-observer-web/src/api/records.ts
+++ b/t-observer-web/src/api/records.ts
@@ -1,0 +1,14 @@
+import type { ApiEnvelope } from '@/types/auth'
+import type { ObservationRecord, RecordDraftPayload, RecordSubmitPayload } from '@/types/record'
+
+import { http } from './http'
+
+export async function saveRecordDraft(payload: RecordDraftPayload) {
+  const response = await http.post<ApiEnvelope<ObservationRecord>>('/records/save-draft', payload)
+  return response.data.data
+}
+
+export async function submitRecord(payload: RecordSubmitPayload) {
+  const response = await http.post<ApiEnvelope<ObservationRecord>>('/records/submit', payload)
+  return response.data.data
+}

--- a/t-observer-web/src/api/records.ts
+++ b/t-observer-web/src/api/records.ts
@@ -12,3 +12,8 @@ export async function submitRecord(payload: RecordSubmitPayload) {
   const response = await http.post<ApiEnvelope<ObservationRecord>>('/records/submit', payload)
   return response.data.data
 }
+
+export async function fetchRecordByTask(taskId: number) {
+  const response = await http.get<ApiEnvelope<ObservationRecord | null>>(`/records/task/${taskId}`)
+  return response.data.data
+}

--- a/t-observer-web/src/api/tasks.ts
+++ b/t-observer-web/src/api/tasks.ts
@@ -1,0 +1,14 @@
+import type { ApiEnvelope } from '@/types/auth'
+import type { TaskCreatePayload, TaskListItem, TaskQueryParams } from '@/types/task'
+
+import { http } from './http'
+
+export async function fetchTasks(params?: TaskQueryParams) {
+  const response = await http.get<ApiEnvelope<TaskListItem[]>>('/tasks', { params })
+  return response.data.data
+}
+
+export async function createTask(payload: TaskCreatePayload) {
+  const response = await http.post<ApiEnvelope<TaskListItem>>('/tasks', payload)
+  return response.data.data
+}

--- a/t-observer-web/src/components/common/StatusTag.vue
+++ b/t-observer-web/src/components/common/StatusTag.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { TASK_STATUS_LABELS, type TaskStatus } from '@/types/task'
+
+const props = defineProps<{
+  status: TaskStatus
+}>()
+
+const label = computed(() => TASK_STATUS_LABELS[props.status] ?? props.status)
+const toneClass = computed(() => `status-tag--${props.status.toLowerCase()}`)
+</script>
+
+<template>
+  <span class="status-tag" :class="toneClass">{{ label }}</span>
+</template>
+
+<style scoped>
+.status-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 72px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.status-tag--pending {
+  color: #b26a1b;
+  background: #fff3e1;
+}
+
+.status-tag--in_progress {
+  color: #2174d7;
+  background: #eaf3ff;
+}
+
+.status-tag--completed {
+  color: #18815a;
+  background: #eaf8f2;
+}
+</style>

--- a/t-observer-web/src/components/record/DimensionScorePanel.vue
+++ b/t-observer-web/src/components/record/DimensionScorePanel.vue
@@ -1,0 +1,150 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { normalizeScores, type ScoreItem } from '@/types/record'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue?: ScoreItem[]
+    disabled?: boolean
+  }>(),
+  {
+    modelValue: () => [],
+    disabled: false,
+  },
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: ScoreItem[]]
+}>()
+
+const scores = computed(() => normalizeScores(props.modelValue))
+
+function updateScore(index: number, value?: number | null) {
+  const nextScores = scores.value.map((score, scoreIndex) =>
+    scoreIndex === index
+      ? {
+          ...score,
+          scoreValue: typeof value === 'number' ? value : null,
+        }
+      : score,
+  )
+
+  emit('update:modelValue', nextScores)
+}
+</script>
+
+<template>
+  <section class="dimension-score-panel">
+    <header class="dimension-score-panel__header">
+      <div>
+        <h3>五维评分</h3>
+        <p>请按照 1.0 到 5.0 的区间完成评分，步长为 0.5。</p>
+      </div>
+    </header>
+
+    <div class="dimension-score-panel__list">
+      <article
+        v-for="(score, index) in scores"
+        :key="score.dimensionCode"
+        class="dimension-score-panel__item"
+      >
+        <div class="dimension-score-panel__meta">
+          <strong>{{ score.dimensionName }}</strong>
+          <span>{{ score.dimensionCode }}</span>
+        </div>
+
+        <div class="dimension-score-panel__control">
+          <el-input-number
+            :model-value="score.scoreValue ?? undefined"
+            :min="1"
+            :max="5"
+            :step="0.5"
+            :precision="1"
+            :disabled="disabled"
+            controls-position="right"
+            @update:model-value="updateScore(index, $event)"
+          />
+          <span class="dimension-score-panel__value">
+            {{ score.scoreValue === null ? '--' : score.scoreValue.toFixed(1) }}
+          </span>
+        </div>
+      </article>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.dimension-score-panel {
+  display: grid;
+  gap: 18px;
+  padding: 20px;
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(64, 158, 255, 0.08), rgba(64, 158, 255, 0.02));
+}
+
+.dimension-score-panel__header h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.dimension-score-panel__header p {
+  margin: 8px 0 0;
+  color: var(--ui-color-text-secondary);
+  font-size: 14px;
+}
+
+.dimension-score-panel__list {
+  display: grid;
+  gap: 12px;
+}
+
+.dimension-score-panel__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.88);
+}
+
+.dimension-score-panel__meta {
+  display: grid;
+  gap: 4px;
+}
+
+.dimension-score-panel__meta strong {
+  font-size: 14px;
+}
+
+.dimension-score-panel__meta span {
+  color: var(--ui-color-text-secondary);
+  font-size: 12px;
+}
+
+.dimension-score-panel__control {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.dimension-score-panel__value {
+  min-width: 36px;
+  font-weight: 600;
+  color: var(--ui-color-primary);
+  text-align: right;
+}
+
+@media (max-width: 640px) {
+  .dimension-score-panel__item {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .dimension-score-panel__control {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+</style>

--- a/t-observer-web/src/layouts/MainLayout.spec.ts
+++ b/t-observer-web/src/layouts/MainLayout.spec.ts
@@ -1,7 +1,7 @@
 import ElementPlus from 'element-plus'
 import { createPinia, setActivePinia } from 'pinia'
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createMemoryHistory, createRouter } from 'vue-router'
 
 import { useAuthStore } from '@/stores/auth'
@@ -52,6 +52,59 @@ describe('MainLayout', () => {
     expect(wrapper.find('[data-testid="app-breadcrumbs"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="user-menu-trigger"]').exists()).toBe(true)
     expect(wrapper.text()).toContain('张老师')
-    expect(wrapper.text()).toContain('组长')
+  })
+
+  it('shows clickable breadcrumb navigation and a back button on the record page', async () => {
+    setActivePinia(createPinia())
+    const authStore = useAuthStore()
+
+    authStore.acceptLogin({
+      token: 'token-2',
+      userId: 2,
+      realName: '李老师',
+      roleCode: 'MEMBER',
+    })
+
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        {
+          path: '/',
+          component: MainLayout,
+          children: [
+            {
+              path: 'member/tasks',
+              name: 'member-task-list',
+              component: { template: '<div>任务列表</div>' },
+            },
+            {
+              path: 'member/tasks/:taskId/record',
+              name: 'member-record-form',
+              component: { template: '<div>记录填写</div>' },
+            },
+          ],
+        },
+      ],
+    })
+
+    await router.push('/member/tasks/7/record')
+    await router.isReady()
+
+    const wrapper = mount(MainLayout, {
+      global: {
+        plugins: [ElementPlus, router],
+      },
+    })
+
+    const pushSpy = vi.spyOn(router, 'push')
+
+    expect(wrapper.text()).toContain('任务')
+    expect(wrapper.text()).toContain('记录填写')
+    expect(wrapper.find('[data-testid="breadcrumb-back"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="breadcrumb-link-member-task-list"]').exists()).toBe(true)
+
+    await wrapper.find('[data-testid="breadcrumb-link-member-task-list"]').trigger('click')
+
+    expect(pushSpy).toHaveBeenCalled()
   })
 })

--- a/t-observer-web/src/layouts/MainLayout.vue
+++ b/t-observer-web/src/layouts/MainLayout.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
 import { ArrowDown, Expand, Fold } from '@element-plus/icons-vue'
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
-import { RouterLink, RouterView, useRoute, useRouter } from 'vue-router'
+import { RouterView, useRoute, useRouter, type RouteLocationRaw } from 'vue-router'
 
 import { useAuthStore } from '@/stores/auth'
+
+type BreadcrumbItem = {
+  label: string
+  to?: RouteLocationRaw
+  testId?: string
+}
 
 const route = useRoute()
 const router = useRouter()
@@ -15,16 +21,16 @@ const mobileDrawerOpen = ref(false)
 const desktopSidebarId = 'app-sidebar-panel-desktop'
 const mobileSidebarId = 'app-sidebar-panel-mobile'
 
-const taskRouteTarget = computed(() => {
+const taskRouteTarget = computed<RouteLocationRaw>(() => {
   if (authStore.roleCode === 'LEADER') {
-    return { name: 'leader-task-manage' as const }
+    return { name: 'leader-task-manage' }
   }
 
   if (authStore.roleCode === 'MEMBER') {
-    return { name: 'member-task-list' as const }
+    return { name: 'member-task-list' }
   }
 
-  return { name: 'dashboard-tasks' as const }
+  return { name: 'dashboard-tasks' }
 })
 
 const navItems = computed(() => [
@@ -39,6 +45,35 @@ const navItems = computed(() => [
     to: taskRouteTarget.value,
   },
 ])
+
+const breadcrumbItems = computed<BreadcrumbItem[]>(() => {
+  switch (route.name) {
+    case 'member-record-form':
+      return [
+        {
+          label: '任务',
+          to: { name: 'member-task-list' },
+          testId: 'breadcrumb-link-member-task-list',
+        },
+        { label: '记录填写' },
+      ]
+    case 'member-task-list':
+    case 'leader-task-manage':
+    case 'dashboard-tasks':
+      return [{ label: '任务' }]
+    case 'dashboard-overview':
+    default:
+      return [{ label: '概览' }]
+  }
+})
+
+const previousBreadcrumb = computed(() => {
+  if (breadcrumbItems.value.length < 2) {
+    return null
+  }
+
+  return breadcrumbItems.value[breadcrumbItems.value.length - 2] ?? null
+})
 
 const updateViewport = () => {
   isMobile.value = window.innerWidth < 992
@@ -63,10 +98,6 @@ const sidebarExpanded = computed(() =>
 const sidebarControlsId = computed(() => (isMobile.value ? mobileSidebarId : desktopSidebarId))
 const sidebarWidth = computed(() => (sidebarCollapsed.value ? '88px' : '244px'))
 const currentRouteName = computed(() => String(route.name ?? ''))
-const activeNavItem = computed(
-  () => navItems.value.find((item) => item.names.includes(currentRouteName.value)) ?? navItems.value[0],
-)
-const activeNavLabel = computed(() => activeNavItem.value?.label ?? '工作台')
 
 function toggleSidebar() {
   if (isMobile.value) {
@@ -85,6 +116,32 @@ function handleNavClick() {
 
 function isNavActive(names: string[]) {
   return names.includes(currentRouteName.value)
+}
+
+async function navigateByBreadcrumb(target?: RouteLocationRaw) {
+  if (!target) {
+    return
+  }
+
+  await router.push(target)
+}
+
+async function navigateByNav(target?: RouteLocationRaw) {
+  if (!target) {
+    return
+  }
+
+  await router.push(target)
+  handleNavClick()
+}
+
+async function goBackByBreadcrumb() {
+  if (previousBreadcrumb.value?.to) {
+    await navigateByBreadcrumb(previousBreadcrumb.value.to)
+    return
+  }
+
+  await router.back()
 }
 
 async function handleLogout() {
@@ -113,16 +170,16 @@ async function handleLogout() {
         </div>
 
         <nav class="sidebar__nav" aria-label="Primary">
-          <RouterLink
+          <button
             v-for="item in navItems"
             :key="item.label"
-            :to="item.to"
+            type="button"
             :class="['sidebar__nav-item', { 'sidebar__nav-item--active': isNavActive(item.names) }]"
             :aria-current="isNavActive(item.names) ? 'page' : undefined"
-            @click="handleNavClick"
+            @click="navigateByNav(item.to)"
           >
             {{ item.label }}
-          </RouterLink>
+          </button>
         </nav>
       </aside>
     </el-drawer>
@@ -145,15 +202,16 @@ async function handleLogout() {
       </div>
 
       <nav class="sidebar__nav" aria-label="Primary">
-        <RouterLink
+        <button
           v-for="item in navItems"
           :key="item.label"
-          :to="item.to"
+          type="button"
           :class="['sidebar__nav-item', { 'sidebar__nav-item--active': isNavActive(item.names) }]"
           :aria-current="isNavActive(item.names) ? 'page' : undefined"
+          @click="navigateByNav(item.to)"
         >
           {{ item.label }}
-        </RouterLink>
+        </button>
       </nav>
     </el-aside>
 
@@ -173,10 +231,37 @@ async function handleLogout() {
             </el-icon>
           </el-button>
 
-          <el-breadcrumb separator="/">
-            <el-breadcrumb-item data-testid="app-breadcrumbs">工作台</el-breadcrumb-item>
-            <el-breadcrumb-item>{{ activeNavLabel }}</el-breadcrumb-item>
-          </el-breadcrumb>
+          <div class="main-layout__breadcrumbs">
+            <el-button
+              v-if="previousBreadcrumb"
+              text
+              circle
+              data-testid="breadcrumb-back"
+              aria-label="返回上一级"
+              @click="goBackByBreadcrumb"
+            >
+              ←
+            </el-button>
+
+            <el-breadcrumb separator="/">
+              <el-breadcrumb-item data-testid="app-breadcrumbs">工作台</el-breadcrumb-item>
+              <el-breadcrumb-item
+                v-for="item in breadcrumbItems"
+                :key="item.label"
+              >
+                <button
+                  v-if="item.to"
+                  type="button"
+                  class="breadcrumb-link"
+                  :data-testid="item.testId"
+                  @click="navigateByBreadcrumb(item.to)"
+                >
+                  {{ item.label }}
+                </button>
+                <span v-else>{{ item.label }}</span>
+              </el-breadcrumb-item>
+            </el-breadcrumb>
+          </div>
         </div>
 
         <el-dropdown trigger="click">
@@ -325,6 +410,22 @@ async function handleLogout() {
 
 .main-layout__toggle {
   color: #334155;
+}
+
+.main-layout__breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.breadcrumb-link {
+  border: none;
+  padding: 0;
+  background: transparent;
+  color: var(--ui-color-primary);
+  cursor: pointer;
+  font: inherit;
 }
 
 .user-trigger {

--- a/t-observer-web/src/layouts/MainLayout.vue
+++ b/t-observer-web/src/layouts/MainLayout.vue
@@ -15,23 +15,30 @@ const mobileDrawerOpen = ref(false)
 const desktopSidebarId = 'app-sidebar-panel-desktop'
 const mobileSidebarId = 'app-sidebar-panel-mobile'
 
-const navItems = [
+const taskRouteTarget = computed(() => {
+  if (authStore.roleCode === 'LEADER') {
+    return { name: 'leader-task-manage' as const }
+  }
+
+  if (authStore.roleCode === 'MEMBER') {
+    return { name: 'member-task-list' as const }
+  }
+
+  return { name: 'dashboard-tasks' as const }
+})
+
+const navItems = computed(() => [
   {
-    name: 'dashboard-overview',
+    names: ['dashboard-overview'],
     label: '概览',
-    to: { name: 'dashboard-overview' },
+    to: { name: 'dashboard-overview' as const },
   },
   {
-    name: 'dashboard-tasks',
+    names: ['dashboard-tasks', 'member-task-list', 'member-record-form', 'leader-task-manage'],
     label: '任务',
-    to: { name: 'dashboard-tasks' },
+    to: taskRouteTarget.value,
   },
-  {
-    name: 'dashboard-records',
-    label: '记录',
-    to: { name: 'dashboard-records' },
-  },
-] as const
+])
 
 const updateViewport = () => {
   isMobile.value = window.innerWidth < 992
@@ -50,13 +57,16 @@ onBeforeUnmount(() => {
 })
 
 const sidebarCollapsed = computed(() => (!isMobile.value ? desktopCollapsed.value : false))
-const sidebarExpanded = computed(() => (isMobile.value ? mobileDrawerOpen.value : !desktopCollapsed.value))
+const sidebarExpanded = computed(() =>
+  isMobile.value ? mobileDrawerOpen.value : !desktopCollapsed.value,
+)
 const sidebarControlsId = computed(() => (isMobile.value ? mobileSidebarId : desktopSidebarId))
 const sidebarWidth = computed(() => (sidebarCollapsed.value ? '88px' : '244px'))
 const currentRouteName = computed(() => String(route.name ?? ''))
 const activeNavItem = computed(
-  () => navItems.find((item) => item.name === currentRouteName.value) ?? navItems[0],
+  () => navItems.value.find((item) => item.names.includes(currentRouteName.value)) ?? navItems.value[0],
 )
+const activeNavLabel = computed(() => activeNavItem.value?.label ?? '工作台')
 
 function toggleSidebar() {
   if (isMobile.value) {
@@ -73,8 +83,8 @@ function handleNavClick() {
   }
 }
 
-function isNavActive(name: string) {
-  return currentRouteName.value === name
+function isNavActive(names: string[]) {
+  return names.includes(currentRouteName.value)
 }
 
 async function handleLogout() {
@@ -105,10 +115,10 @@ async function handleLogout() {
         <nav class="sidebar__nav" aria-label="Primary">
           <RouterLink
             v-for="item in navItems"
-            :key="item.name"
+            :key="item.label"
             :to="item.to"
-            :class="['sidebar__nav-item', { 'sidebar__nav-item--active': isNavActive(item.name) }]"
-            :aria-current="isNavActive(item.name) ? 'page' : undefined"
+            :class="['sidebar__nav-item', { 'sidebar__nav-item--active': isNavActive(item.names) }]"
+            :aria-current="isNavActive(item.names) ? 'page' : undefined"
             @click="handleNavClick"
           >
             {{ item.label }}
@@ -137,10 +147,10 @@ async function handleLogout() {
       <nav class="sidebar__nav" aria-label="Primary">
         <RouterLink
           v-for="item in navItems"
-          :key="item.name"
+          :key="item.label"
           :to="item.to"
-          :class="['sidebar__nav-item', { 'sidebar__nav-item--active': isNavActive(item.name) }]"
-          :aria-current="isNavActive(item.name) ? 'page' : undefined"
+          :class="['sidebar__nav-item', { 'sidebar__nav-item--active': isNavActive(item.names) }]"
+          :aria-current="isNavActive(item.names) ? 'page' : undefined"
         >
           {{ item.label }}
         </RouterLink>
@@ -165,7 +175,7 @@ async function handleLogout() {
 
           <el-breadcrumb separator="/">
             <el-breadcrumb-item data-testid="app-breadcrumbs">工作台</el-breadcrumb-item>
-            <el-breadcrumb-item>{{ activeNavItem.label }}</el-breadcrumb-item>
+            <el-breadcrumb-item>{{ activeNavLabel }}</el-breadcrumb-item>
           </el-breadcrumb>
         </div>
 

--- a/t-observer-web/src/router/index.spec.ts
+++ b/t-observer-web/src/router/index.spec.ts
@@ -64,4 +64,22 @@ describe('app router auth guard', () => {
     expect(store.token).toBe('')
     expect(store.isValidated).toBe(false)
   })
+
+  it('routes /tasks to the member task page after restoring a member session', async () => {
+    window.localStorage.setItem('t-observer-token', 'member-token')
+    setActivePinia(createPinia())
+    const router = createAppRouter(createMemoryHistory())
+
+    vi.mocked(fetchCurrentUser).mockResolvedValue({
+      userId: 2,
+      username: 'member01',
+      realName: '李老师',
+      roleCode: 'MEMBER',
+    })
+
+    await router.push('/tasks')
+    await router.isReady()
+
+    expect(router.currentRoute.value.fullPath).toBe('/member/tasks')
+  })
 })

--- a/t-observer-web/src/router/index.ts
+++ b/t-observer-web/src/router/index.ts
@@ -9,7 +9,11 @@ import {
 import { fetchCurrentUser } from '@/api/auth'
 import MainLayout from '@/layouts/MainLayout.vue'
 import { useAuthStore } from '@/stores/auth'
+import type { RoleCode } from '@/types/auth'
+import LeaderTaskManageView from '@/views/leader/LeaderTaskManageView.vue'
 import LoginView from '@/views/login/LoginView.vue'
+import MemberTaskListView from '@/views/member/MemberTaskListView.vue'
+import RecordFormView from '@/views/member/RecordFormView.vue'
 
 const createPreviewPage = (title: string, description: string) =>
   defineComponent({
@@ -23,9 +27,19 @@ const createPreviewPage = (title: string, description: string) =>
     },
   })
 
-const OverviewPreview = createPreviewPage('概览', '这是当前主布局的占位预览页。')
-const TasksPreview = createPreviewPage('任务', '任务页面尚未接入，本页用于保持主布局内容完整。')
-const RecordsPreview = createPreviewPage('记录', '记录页面尚未接入，本页用于保持主布局内容完整。')
+const OverviewPreview = createPreviewPage('概览', '当前页面用于保留主布局概览入口。')
+
+function resolveRoleTaskRoute(roleCode: RoleCode | '') {
+  if (roleCode === 'LEADER') {
+    return { name: 'leader-task-manage' as const }
+  }
+
+  if (roleCode === 'MEMBER') {
+    return { name: 'member-task-list' as const }
+  }
+
+  return { name: 'dashboard-overview' as const }
+}
 
 const routes: RouteRecordRaw[] = [
   {
@@ -35,7 +49,7 @@ const routes: RouteRecordRaw[] = [
     children: [
       {
         path: '',
-        redirect: { name: 'dashboard-overview' },
+        redirect: { name: 'dashboard-tasks' },
       },
       {
         path: 'overview',
@@ -46,13 +60,25 @@ const routes: RouteRecordRaw[] = [
       {
         path: 'tasks',
         name: 'dashboard-tasks',
-        component: TasksPreview,
+        component: OverviewPreview,
         meta: { requiresAuth: true },
       },
       {
-        path: 'records',
-        name: 'dashboard-records',
-        component: RecordsPreview,
+        path: 'member/tasks',
+        name: 'member-task-list',
+        component: MemberTaskListView,
+        meta: { requiresAuth: true },
+      },
+      {
+        path: 'member/tasks/:taskId/record',
+        name: 'member-record-form',
+        component: RecordFormView,
+        meta: { requiresAuth: true },
+      },
+      {
+        path: 'leader/tasks',
+        name: 'leader-task-manage',
+        component: LeaderTaskManageView,
         meta: { requiresAuth: true },
       },
     ],
@@ -94,7 +120,11 @@ export function createAppRouter(
     }
 
     if (guestOnly) {
-      return { name: 'dashboard-overview' }
+      return resolveRoleTaskRoute(authStore.roleCode)
+    }
+
+    if (to.name === 'dashboard-tasks') {
+      return resolveRoleTaskRoute(authStore.roleCode)
     }
 
     return true

--- a/t-observer-web/src/types/auth.ts
+++ b/t-observer-web/src/types/auth.ts
@@ -19,6 +19,8 @@ export type CurrentUserResponse = {
   roleCode: RoleCode
 }
 
+export type MemberOption = CurrentUserResponse
+
 export type ApiEnvelope<T> = {
   code: number
   message: string

--- a/t-observer-web/src/types/record.ts
+++ b/t-observer-web/src/types/record.ts
@@ -1,0 +1,69 @@
+export type DimensionCode =
+  | 'TEACHING_DESIGN'
+  | 'CLASSROOM_ORGANIZATION'
+  | 'TEACHING_CONTENT'
+  | 'INTERACTION_FEEDBACK'
+  | 'TEACHING_EFFECTIVENESS'
+
+export type ScoreItem = {
+  dimensionCode: DimensionCode
+  dimensionName: string
+  scoreValue: number | null
+}
+
+export type RecordDraftPayload = {
+  taskId: number
+  teacherName: string
+  strengths: string
+  weaknesses: string
+  suggestions: string
+  scores: ScoreItem[]
+}
+
+export type RecordSubmitPayload = RecordDraftPayload
+
+export type ObservationRecord = {
+  id: number
+  taskId: number
+  observerId: number
+  teacherName: string
+  strengths: string
+  weaknesses: string
+  suggestions: string
+  status: string
+  rejectReason: string | null
+  submittedAt: string | null
+  approvedAt: string | null
+  scores: ScoreItem[]
+}
+
+export const DIMENSION_OPTIONS: Array<Pick<ScoreItem, 'dimensionCode' | 'dimensionName'>> = [
+  { dimensionCode: 'TEACHING_DESIGN', dimensionName: '教学设计' },
+  { dimensionCode: 'CLASSROOM_ORGANIZATION', dimensionName: '课堂组织' },
+  { dimensionCode: 'TEACHING_CONTENT', dimensionName: '教学内容' },
+  { dimensionCode: 'INTERACTION_FEEDBACK', dimensionName: '互动反馈' },
+  { dimensionCode: 'TEACHING_EFFECTIVENESS', dimensionName: '教学效果' },
+]
+
+export function createEmptyScores(): ScoreItem[] {
+  return DIMENSION_OPTIONS.map((dimension) => ({
+    ...dimension,
+    scoreValue: null,
+  }))
+}
+
+export function normalizeScores(scores?: Partial<ScoreItem>[]): ScoreItem[] {
+  const scoreByCode = new Map(
+    (scores ?? []).map((score) => [score.dimensionCode, score] as const),
+  )
+
+  return DIMENSION_OPTIONS.map((dimension) => {
+    const existing = scoreByCode.get(dimension.dimensionCode)
+
+    return {
+      dimensionCode: dimension.dimensionCode,
+      dimensionName: existing?.dimensionName?.trim() || dimension.dimensionName,
+      scoreValue: typeof existing?.scoreValue === 'number' ? existing.scoreValue : null,
+    }
+  })
+}

--- a/t-observer-web/src/types/task.ts
+++ b/t-observer-web/src/types/task.ts
@@ -1,0 +1,41 @@
+export type TaskStatus = 'PENDING' | 'IN_PROGRESS' | 'COMPLETED'
+
+export type TaskListItem = {
+  id: number
+  title: string
+  observerId: number
+  observerName: string
+  teacherName: string
+  courseName: string
+  lessonTime: string
+  deadline: string
+  status: TaskStatus
+  remark: string | null
+}
+
+export type TaskQueryParams = {
+  status?: TaskStatus
+}
+
+export type TaskCreatePayload = {
+  title: string
+  observerId: number
+  teacherName: string
+  courseName: string
+  lessonTime: string
+  deadline: string
+  remark?: string
+}
+
+export const TASK_STATUS_LABELS: Record<TaskStatus, string> = {
+  PENDING: '待填写',
+  IN_PROGRESS: '进行中',
+  COMPLETED: '已完成',
+}
+
+export const TASK_STATUS_FILTERS: Array<{ label: string; value: TaskStatus | 'ALL' }> = [
+  { label: '全部', value: 'ALL' },
+  { label: TASK_STATUS_LABELS.PENDING, value: 'PENDING' },
+  { label: TASK_STATUS_LABELS.IN_PROGRESS, value: 'IN_PROGRESS' },
+  { label: TASK_STATUS_LABELS.COMPLETED, value: 'COMPLETED' },
+]

--- a/t-observer-web/src/views/leader/LeaderTaskManageView.spec.ts
+++ b/t-observer-web/src/views/leader/LeaderTaskManageView.spec.ts
@@ -2,6 +2,7 @@ import ElementPlus from 'element-plus'
 import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { fetchMembers } from '@/api/auth'
 import { fetchTasks } from '@/api/tasks'
 
 import LeaderTaskManageView from './LeaderTaskManageView.vue'
@@ -10,6 +11,14 @@ vi.mock('@/api/tasks', () => ({
   fetchTasks: vi.fn(),
   createTask: vi.fn(),
 }))
+
+vi.mock('@/api/auth', async () => {
+  const actual = await vi.importActual<typeof import('@/api/auth')>('@/api/auth')
+  return {
+    ...actual,
+    fetchMembers: vi.fn(),
+  }
+})
 
 describe('LeaderTaskManageView', () => {
   afterEach(() => {
@@ -50,6 +59,14 @@ describe('LeaderTaskManageView', () => {
 
   it('shows the empty state when the leader has no tasks yet', async () => {
     vi.mocked(fetchTasks).mockResolvedValue([])
+    vi.mocked(fetchMembers).mockResolvedValue([
+      {
+        userId: 2,
+        username: 'member01',
+        realName: '李老师',
+        roleCode: 'MEMBER',
+      },
+    ])
 
     const wrapper = mount(LeaderTaskManageView, {
       global: {
@@ -64,5 +81,32 @@ describe('LeaderTaskManageView', () => {
     await vi.waitFor(() => {
       expect(wrapper.text()).toContain('可以先创建一条听课任务')
     })
+  })
+
+  it('loads member options and uses member name selection instead of raw id input', async () => {
+    vi.mocked(fetchTasks).mockResolvedValue([])
+    vi.mocked(fetchMembers).mockResolvedValue([
+      {
+        userId: 2,
+        username: 'member01',
+        realName: '李老师',
+        roleCode: 'MEMBER',
+      },
+    ])
+
+    const wrapper = mount(LeaderTaskManageView, {
+      global: {
+        plugins: [ElementPlus],
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(fetchMembers).toHaveBeenCalled()
+    })
+
+    await wrapper.findAll('button').find((button) => button.text().includes('新建任务'))?.trigger('click')
+
+    expect(wrapper.text()).toContain('听课成员')
+    expect(wrapper.text()).not.toContain('听课成员 ID')
   })
 })

--- a/t-observer-web/src/views/leader/LeaderTaskManageView.spec.ts
+++ b/t-observer-web/src/views/leader/LeaderTaskManageView.spec.ts
@@ -1,0 +1,68 @@
+import ElementPlus from 'element-plus'
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchTasks } from '@/api/tasks'
+
+import LeaderTaskManageView from './LeaderTaskManageView.vue'
+
+vi.mock('@/api/tasks', () => ({
+  fetchTasks: vi.fn(),
+  createTask: vi.fn(),
+}))
+
+describe('LeaderTaskManageView', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the leader task list from API data', async () => {
+    vi.mocked(fetchTasks).mockResolvedValue([
+      {
+        id: 1,
+        title: '高一数学听课',
+        observerId: 2,
+        observerName: '李老师',
+        teacherName: '赵老师',
+        courseName: '函数概念',
+        lessonTime: '2026-04-20T09:00:00',
+        deadline: '2026-04-22T18:00:00',
+        status: 'PENDING',
+        remark: '重点观察课堂互动',
+      },
+    ])
+
+    const wrapper = mount(LeaderTaskManageView, {
+      global: {
+        plugins: [ElementPlus],
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain('高一数学听课')
+    })
+
+    expect(wrapper.text()).toContain('任务管理')
+    expect(wrapper.text()).toContain('新建任务')
+    expect(wrapper.text()).toContain('赵老师')
+    expect(wrapper.text()).toContain('待填写')
+  })
+
+  it('shows the empty state when the leader has no tasks yet', async () => {
+    vi.mocked(fetchTasks).mockResolvedValue([])
+
+    const wrapper = mount(LeaderTaskManageView, {
+      global: {
+        plugins: [ElementPlus],
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(fetchTasks).toHaveBeenCalled()
+    })
+
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain('可以先创建一条听课任务')
+    })
+  })
+})

--- a/t-observer-web/src/views/leader/LeaderTaskManageView.vue
+++ b/t-observer-web/src/views/leader/LeaderTaskManageView.vue
@@ -3,8 +3,10 @@ import type { AxiosError } from 'axios'
 import { ElMessage, type FormInstance, type FormRules } from 'element-plus'
 import { computed, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
 
+import { fetchMembers } from '@/api/auth'
 import { createTask, fetchTasks } from '@/api/tasks'
 import StatusTag from '@/components/common/StatusTag.vue'
+import type { MemberOption } from '@/types/auth'
 import {
   TASK_STATUS_FILTERS,
   type TaskCreatePayload,
@@ -15,8 +17,10 @@ import {
 const loading = ref(false)
 const drawerOpen = ref(false)
 const creating = ref(false)
+const membersLoading = ref(false)
 const errorMessage = ref('')
 const tasks = ref<TaskListItem[]>([])
+const memberOptions = ref<MemberOption[]>([])
 const activeFilter = ref<TaskStatus | 'ALL'>('ALL')
 const isMobile = ref(false)
 const formRef = ref<FormInstance>()
@@ -57,19 +61,32 @@ async function loadTasks() {
   }
 }
 
+async function loadMembers(keyword = '') {
+  membersLoading.value = true
+
+  try {
+    memberOptions.value = await fetchMembers(keyword.trim() || undefined)
+  } catch (error) {
+    ElMessage.error(getAxiosMessage(error, '成员列表加载失败，请稍后重试'))
+    memberOptions.value = []
+  } finally {
+    membersLoading.value = false
+  }
+}
+
 const rules: FormRules<TaskCreatePayload> = {
   title: [{ required: true, message: '请输入任务标题', trigger: 'blur' }],
   observerId: [
-    { required: true, message: '请输入听课成员 ID', trigger: 'blur' },
+    { required: true, message: '请选择听课成员', trigger: 'change' },
     {
       validator: (_, value, callback) => {
         if (typeof value !== 'number' || Number.isNaN(value) || value <= 0) {
-          callback(new Error('成员 ID 必须为正整数'))
+          callback(new Error('请选择有效的听课成员'))
           return
         }
         callback()
       },
-      trigger: 'blur',
+      trigger: 'change',
     },
   ],
   teacherName: [{ required: true, message: '请输入授课教师', trigger: 'blur' }],
@@ -151,10 +168,19 @@ async function handleCreateTask() {
   }
 }
 
+function formatMemberLabel(member: MemberOption) {
+  return `${member.realName}（${member.username}）`
+}
+
+async function handleMemberSearch(keyword: string) {
+  await loadMembers(keyword)
+}
+
 onMounted(() => {
   updateViewport()
   window.addEventListener('resize', updateViewport)
   void loadTasks()
+  void loadMembers()
 })
 
 onBeforeUnmount(() => {
@@ -244,6 +270,7 @@ onBeforeUnmount(() => {
       title="新建听课任务"
       size="420px"
       destroy-on-close
+      @opened="loadMembers()"
       @closed="formRef?.resetFields()"
     >
       <el-form ref="formRef" :model="form" :rules="rules" label-position="top">
@@ -251,8 +278,25 @@ onBeforeUnmount(() => {
           <el-input v-model="form.title" placeholder="例如：高一数学听课" />
         </el-form-item>
 
-        <el-form-item label="听课成员 ID" prop="observerId">
-          <el-input-number v-model="form.observerId" :min="1" :step="1" style="width: 100%" />
+        <el-form-item label="听课成员" prop="observerId">
+          <el-select
+            v-model="form.observerId"
+            filterable
+            remote
+            reserve-keyword
+            clearable
+            placeholder="请选择或搜索听课成员"
+            :remote-method="handleMemberSearch"
+            :loading="membersLoading"
+            style="width: 100%"
+          >
+            <el-option
+              v-for="member in memberOptions"
+              :key="member.userId"
+              :label="formatMemberLabel(member)"
+              :value="member.userId"
+            />
+          </el-select>
         </el-form-item>
 
         <el-form-item label="授课教师" prop="teacherName">

--- a/t-observer-web/src/views/leader/LeaderTaskManageView.vue
+++ b/t-observer-web/src/views/leader/LeaderTaskManageView.vue
@@ -1,0 +1,411 @@
+<script setup lang="ts">
+import type { AxiosError } from 'axios'
+import { ElMessage, type FormInstance, type FormRules } from 'element-plus'
+import { computed, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
+
+import { createTask, fetchTasks } from '@/api/tasks'
+import StatusTag from '@/components/common/StatusTag.vue'
+import {
+  TASK_STATUS_FILTERS,
+  type TaskCreatePayload,
+  type TaskListItem,
+  type TaskStatus,
+} from '@/types/task'
+
+const loading = ref(false)
+const drawerOpen = ref(false)
+const creating = ref(false)
+const errorMessage = ref('')
+const tasks = ref<TaskListItem[]>([])
+const activeFilter = ref<TaskStatus | 'ALL'>('ALL')
+const isMobile = ref(false)
+const formRef = ref<FormInstance>()
+
+const form = reactive<TaskCreatePayload>({
+  title: '',
+  observerId: 0,
+  teacherName: '',
+  courseName: '',
+  lessonTime: '',
+  deadline: '',
+  remark: '',
+})
+
+function updateViewport() {
+  isMobile.value = window.innerWidth < 768
+}
+
+function getAxiosMessage(error: unknown, fallback: string) {
+  return (
+    ((error as AxiosError<{ message?: string }>)?.response?.data?.message ?? '').trim() || fallback
+  )
+}
+
+async function loadTasks() {
+  loading.value = true
+  errorMessage.value = ''
+
+  try {
+    tasks.value = await fetchTasks(
+      activeFilter.value === 'ALL' ? undefined : { status: activeFilter.value },
+    )
+  } catch {
+    errorMessage.value = '任务加载失败，请稍后重试'
+    tasks.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+const rules: FormRules<TaskCreatePayload> = {
+  title: [{ required: true, message: '请输入任务标题', trigger: 'blur' }],
+  observerId: [
+    { required: true, message: '请输入听课成员 ID', trigger: 'blur' },
+    {
+      validator: (_, value, callback) => {
+        if (typeof value !== 'number' || Number.isNaN(value) || value <= 0) {
+          callback(new Error('成员 ID 必须为正整数'))
+          return
+        }
+        callback()
+      },
+      trigger: 'blur',
+    },
+  ],
+  teacherName: [{ required: true, message: '请输入授课教师', trigger: 'blur' }],
+  courseName: [{ required: true, message: '请输入课程名称', trigger: 'blur' }],
+  lessonTime: [{ required: true, message: '请选择听课时间', trigger: 'change' }],
+  deadline: [
+    { required: true, message: '请选择截止时间', trigger: 'change' },
+    {
+      validator: (_, value, callback) => {
+        if (!value || !form.lessonTime) {
+          callback()
+          return
+        }
+
+        const lessonTime = new Date(form.lessonTime).getTime()
+        const deadline = new Date(value).getTime()
+        if (deadline < lessonTime) {
+          callback(new Error('截止时间不能早于听课时间'))
+          return
+        }
+
+        callback()
+      },
+      trigger: 'change',
+    },
+  ],
+}
+
+const emptyDescription = computed(() =>
+  activeFilter.value === 'ALL'
+    ? '可以先创建一条听课任务，分配给成员开始填写记录。'
+    : '当前筛选条件下暂无任务，建议切换状态或新建任务。',
+)
+
+function resetForm() {
+  form.title = ''
+  form.observerId = 0
+  form.teacherName = ''
+  form.courseName = ''
+  form.lessonTime = ''
+  form.deadline = ''
+  form.remark = ''
+}
+
+async function switchFilter(filter: TaskStatus | 'ALL') {
+  if (activeFilter.value === filter) {
+    return
+  }
+
+  activeFilter.value = filter
+  await loadTasks()
+}
+
+async function handleCreateTask() {
+  const isValid = await formRef.value
+    ?.validate()
+    .then(() => true)
+    .catch(() => false)
+
+  if (!isValid) {
+    return
+  }
+
+  creating.value = true
+
+  try {
+    await createTask({
+      ...form,
+      remark: form.remark?.trim() || undefined,
+    })
+    ElMessage.success('任务创建成功')
+    drawerOpen.value = false
+    resetForm()
+    await loadTasks()
+  } catch (error) {
+    ElMessage.error(getAxiosMessage(error, '任务创建失败，请稍后重试'))
+  } finally {
+    creating.value = false
+  }
+}
+
+onMounted(() => {
+  updateViewport()
+  window.addEventListener('resize', updateViewport)
+  void loadTasks()
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', updateViewport)
+})
+</script>
+
+<template>
+  <section class="leader-task-page">
+    <header class="leader-task-page__hero">
+      <div>
+        <p class="leader-task-page__eyebrow">组长任务</p>
+        <h1>任务管理</h1>
+        <p>查看自己创建的任务，按状态筛选，并通过右侧抽屉快速创建新任务。</p>
+      </div>
+      <el-button type="primary" @click="drawerOpen = true">新建任务</el-button>
+    </header>
+
+    <section class="leader-task-page__filters">
+      <button
+        v-for="filter in TASK_STATUS_FILTERS"
+        :key="filter.value"
+        class="leader-task-page__filter"
+        :class="{ 'leader-task-page__filter--active': activeFilter === filter.value }"
+        type="button"
+        @click="switchFilter(filter.value)"
+      >
+        {{ filter.label }}
+      </button>
+    </section>
+
+    <section v-if="loading" class="leader-task-page__skeletons">
+      <el-skeleton v-for="item in 4" :key="item" animated />
+    </section>
+
+    <el-result
+      v-else-if="errorMessage"
+      icon="warning"
+      title="任务加载失败"
+      :sub-title="errorMessage"
+    >
+      <template #extra>
+        <el-button type="primary" @click="loadTasks">重新加载</el-button>
+      </template>
+    </el-result>
+
+    <el-empty v-else-if="tasks.length === 0" :description="emptyDescription" />
+
+    <template v-else>
+      <el-table v-if="!isMobile" :data="tasks" class="leader-task-page__table">
+        <el-table-column prop="title" label="任务标题" min-width="180" />
+        <el-table-column prop="observerName" label="听课成员" min-width="120" />
+        <el-table-column prop="teacherName" label="授课教师" min-width="120" />
+        <el-table-column prop="courseName" label="课程名称" min-width="140" />
+        <el-table-column label="听课时间" min-width="160">
+          <template #default="{ row }">{{ row.lessonTime.replace('T', ' ') }}</template>
+        </el-table-column>
+        <el-table-column label="截止时间" min-width="160">
+          <template #default="{ row }">{{ row.deadline.replace('T', ' ') }}</template>
+        </el-table-column>
+        <el-table-column label="状态" width="120">
+          <template #default="{ row }">
+            <StatusTag :status="row.status" />
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <section v-else class="leader-task-page__cards">
+        <article v-for="task in tasks" :key="task.id" class="leader-task-card">
+          <div class="leader-task-card__header">
+            <div>
+              <h2>{{ task.title }}</h2>
+              <p>{{ task.teacherName }} · {{ task.courseName }}</p>
+            </div>
+            <StatusTag :status="task.status" />
+          </div>
+
+          <p>成员：{{ task.observerName || `ID ${task.observerId}` }}</p>
+          <p>听课时间：{{ task.lessonTime.replace('T', ' ') }}</p>
+          <p>截止时间：{{ task.deadline.replace('T', ' ') }}</p>
+        </article>
+      </section>
+    </template>
+
+    <el-drawer
+      v-model="drawerOpen"
+      title="新建听课任务"
+      size="420px"
+      destroy-on-close
+      @closed="formRef?.resetFields()"
+    >
+      <el-form ref="formRef" :model="form" :rules="rules" label-position="top">
+        <el-form-item label="任务标题" prop="title">
+          <el-input v-model="form.title" placeholder="例如：高一数学听课" />
+        </el-form-item>
+
+        <el-form-item label="听课成员 ID" prop="observerId">
+          <el-input-number v-model="form.observerId" :min="1" :step="1" style="width: 100%" />
+        </el-form-item>
+
+        <el-form-item label="授课教师" prop="teacherName">
+          <el-input v-model="form.teacherName" placeholder="请输入授课教师姓名" />
+        </el-form-item>
+
+        <el-form-item label="课程名称" prop="courseName">
+          <el-input v-model="form.courseName" placeholder="请输入课程名称" />
+        </el-form-item>
+
+        <el-form-item label="听课时间" prop="lessonTime">
+          <el-date-picker
+            v-model="form.lessonTime"
+            type="datetime"
+            value-format="YYYY-MM-DDTHH:mm:ss"
+            placeholder="请选择听课时间"
+            style="width: 100%"
+          />
+        </el-form-item>
+
+        <el-form-item label="截止时间" prop="deadline">
+          <el-date-picker
+            v-model="form.deadline"
+            type="datetime"
+            value-format="YYYY-MM-DDTHH:mm:ss"
+            placeholder="请选择截止时间"
+            style="width: 100%"
+          />
+        </el-form-item>
+
+        <el-form-item label="备注">
+          <el-input
+            v-model="form.remark"
+            type="textarea"
+            :rows="4"
+            placeholder="可填写本次任务希望重点关注的课堂要点。"
+          />
+        </el-form-item>
+      </el-form>
+
+      <template #footer>
+        <div class="leader-task-page__drawer-footer">
+          <el-button @click="drawerOpen = false">取消</el-button>
+          <el-button type="primary" :loading="creating" @click="handleCreateTask">
+            创建任务
+          </el-button>
+        </div>
+      </template>
+    </el-drawer>
+  </section>
+</template>
+
+<style scoped>
+.leader-task-page {
+  display: grid;
+  gap: 20px;
+}
+
+.leader-task-page__hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 24px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(64, 158, 255, 0.12), rgba(64, 158, 255, 0.03));
+}
+
+.leader-task-page__hero h1 {
+  margin: 6px 0 0;
+  font-size: 24px;
+}
+
+.leader-task-page__hero p {
+  margin: 10px 0 0;
+  color: var(--ui-color-text-secondary);
+  line-height: 1.6;
+}
+
+.leader-task-page__eyebrow {
+  margin: 0;
+  color: var(--ui-color-primary);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.leader-task-page__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.leader-task-page__filter {
+  padding: 10px 16px;
+  border: none;
+  border-radius: 999px;
+  background: #eef3f8;
+  color: #425466;
+  cursor: pointer;
+}
+
+.leader-task-page__filter--active {
+  background: var(--ui-color-primary);
+  color: #fff;
+}
+
+.leader-task-page__table {
+  overflow: hidden;
+  border-radius: 16px;
+}
+
+.leader-task-page__cards {
+  display: grid;
+  gap: 16px;
+}
+
+.leader-task-card {
+  padding: 20px;
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.06);
+}
+
+.leader-task-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.leader-task-card__header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.leader-task-card__header p,
+.leader-task-card p {
+  margin: 8px 0 0;
+  color: var(--ui-color-text-secondary);
+}
+
+.leader-task-page__drawer-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+@media (max-width: 768px) {
+  .leader-task-page__hero,
+  .leader-task-card__header {
+    flex-direction: column;
+  }
+}
+</style>

--- a/t-observer-web/src/views/login/LoginView.vue
+++ b/t-observer-web/src/views/login/LoginView.vue
@@ -40,7 +40,7 @@ async function submitLogin() {
     })
 
     authStore.acceptLogin(payload)
-    await router.push('/overview')
+    await router.push('/tasks')
   } catch {
     ElMessage.error('登录失败，请检查用户名或密码')
   } finally {

--- a/t-observer-web/src/views/member/MemberTaskListView.spec.ts
+++ b/t-observer-web/src/views/member/MemberTaskListView.spec.ts
@@ -1,0 +1,92 @@
+import ElementPlus from 'element-plus'
+import { mount, RouterLinkStub } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchTasks } from '@/api/tasks'
+
+import MemberTaskListView from './MemberTaskListView.vue'
+
+vi.mock('@/api/tasks', () => ({
+  fetchTasks: vi.fn(),
+}))
+
+describe('MemberTaskListView', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders task filters, cards, and action labels from API data', async () => {
+    vi.mocked(fetchTasks).mockResolvedValue([
+      {
+        id: 1,
+        title: '高一数学听课',
+        observerId: 2,
+        observerName: '李老师',
+        teacherName: '赵老师',
+        courseName: '函数概念',
+        lessonTime: '2026-04-20T09:00:00',
+        deadline: '2026-04-22T18:00:00',
+        status: 'PENDING',
+        remark: '重点观察课堂互动',
+      },
+      {
+        id: 2,
+        title: '高二英语听课',
+        observerId: 2,
+        observerName: '李老师',
+        teacherName: '王老师',
+        courseName: '阅读理解',
+        lessonTime: '2026-04-23T10:00:00',
+        deadline: '2026-04-25T18:00:00',
+        status: 'COMPLETED',
+        remark: '',
+      },
+    ])
+
+    const wrapper = mount(MemberTaskListView, {
+      global: {
+        plugins: [ElementPlus],
+        stubs: {
+          RouterLink: RouterLinkStub,
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(fetchTasks).toHaveBeenCalledWith(undefined)
+    })
+
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain('高一数学听课')
+    })
+
+    expect(wrapper.text()).toContain('全部')
+    expect(wrapper.text()).toContain('待填写')
+    expect(wrapper.text()).toContain('进行中')
+    expect(wrapper.text()).toContain('已完成')
+    expect(wrapper.text()).toContain('高二英语听课')
+    expect(wrapper.text()).toContain('去填报')
+    expect(wrapper.text()).toContain('查看任务')
+  })
+
+  it('shows the empty state when there are no tasks', async () => {
+    vi.mocked(fetchTasks).mockResolvedValue([])
+
+    const wrapper = mount(MemberTaskListView, {
+      global: {
+        plugins: [ElementPlus],
+        stubs: {
+          RouterLink: RouterLinkStub,
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(fetchTasks).toHaveBeenCalled()
+    })
+
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain('暂无听课任务')
+    })
+  })
+})

--- a/t-observer-web/src/views/member/MemberTaskListView.vue
+++ b/t-observer-web/src/views/member/MemberTaskListView.vue
@@ -1,0 +1,358 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import type { LocationQueryRaw } from 'vue-router'
+
+import { fetchTasks } from '@/api/tasks'
+import StatusTag from '@/components/common/StatusTag.vue'
+import {
+  TASK_STATUS_FILTERS,
+  TASK_STATUS_LABELS,
+  type TaskListItem,
+  type TaskStatus,
+} from '@/types/task'
+
+const loading = ref(false)
+const errorMessage = ref('')
+const tasks = ref<TaskListItem[]>([])
+const activeFilter = ref<TaskStatus | 'ALL'>('ALL')
+
+const hasTasks = computed(() => tasks.value.length > 0)
+
+function formatDateTime(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return new Intl.DateTimeFormat('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
+}
+
+function buildTaskQuery(task: TaskListItem): LocationQueryRaw {
+  return {
+    title: task.title,
+    teacherName: task.teacherName,
+    courseName: task.courseName,
+    lessonTime: task.lessonTime,
+    deadline: task.deadline,
+    remark: task.remark ?? '',
+    status: task.status,
+  }
+}
+
+function getActionText(status: TaskStatus) {
+  switch (status) {
+    case 'PENDING':
+      return '去填报'
+    case 'IN_PROGRESS':
+      return '继续填报'
+    case 'COMPLETED':
+      return '查看任务'
+  }
+}
+
+async function loadTasks() {
+  loading.value = true
+  errorMessage.value = ''
+
+  try {
+    tasks.value = await fetchTasks(
+      activeFilter.value === 'ALL' ? undefined : { status: activeFilter.value },
+    )
+  } catch {
+    errorMessage.value = '任务加载失败，请稍后重试'
+    tasks.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+async function switchFilter(filter: TaskStatus | 'ALL') {
+  if (activeFilter.value === filter) {
+    return
+  }
+
+  activeFilter.value = filter
+  await loadTasks()
+}
+
+onMounted(loadTasks)
+</script>
+
+<template>
+  <section class="member-task-page">
+    <header class="member-task-page__hero">
+      <div>
+        <p class="member-task-page__eyebrow">成员任务</p>
+        <h1>我的听课任务</h1>
+        <p>成员仅能查看分配给自己的听课任务，并从任务卡片进入独立记录页。</p>
+      </div>
+      <el-tag effect="plain" round>MEMBER</el-tag>
+    </header>
+
+    <section class="member-task-page__filters">
+      <button
+        v-for="filter in TASK_STATUS_FILTERS"
+        :key="filter.value"
+        class="member-task-page__filter"
+        :class="{ 'member-task-page__filter--active': activeFilter === filter.value }"
+        type="button"
+        @click="switchFilter(filter.value)"
+      >
+        {{ filter.label }}
+      </button>
+    </section>
+
+    <section v-if="loading" class="member-task-page__grid">
+      <el-skeleton v-for="item in 3" :key="item" animated class="member-task-page__skeleton">
+        <template #template>
+          <el-skeleton-item variant="p" style="width: 42%" />
+          <el-skeleton-item variant="text" style="margin-top: 16px; width: 100%" />
+          <el-skeleton-item variant="text" style="width: 72%" />
+          <el-skeleton-item variant="button" style="margin-top: 20px; width: 120px" />
+        </template>
+      </el-skeleton>
+    </section>
+
+    <el-result
+      v-else-if="errorMessage"
+      icon="warning"
+      title="任务加载失败"
+      :sub-title="errorMessage"
+    >
+      <template #extra>
+        <el-button type="primary" @click="loadTasks">重新加载</el-button>
+      </template>
+    </el-result>
+
+    <el-empty
+      v-else-if="!hasTasks"
+      description="当前筛选条件下没有待处理任务，可稍后刷新查看。"
+    >
+      <template #default>
+        <div class="member-task-page__empty">
+          <strong>暂无听课任务</strong>
+        </div>
+      </template>
+    </el-empty>
+
+    <section v-else class="member-task-page__grid">
+      <article v-for="task in tasks" :key="task.id" class="task-card">
+        <div class="task-card__header">
+          <div>
+            <h2>{{ task.title }}</h2>
+            <p>{{ task.teacherName }} · {{ task.courseName }}</p>
+          </div>
+          <StatusTag :status="task.status" />
+        </div>
+
+        <dl class="task-card__meta">
+          <div>
+            <dt>听课时间</dt>
+            <dd>{{ formatDateTime(task.lessonTime) }}</dd>
+          </div>
+          <div>
+            <dt>截止时间</dt>
+            <dd>{{ formatDateTime(task.deadline) }}</dd>
+          </div>
+        </dl>
+
+        <p v-if="task.remark" class="task-card__remark">{{ task.remark }}</p>
+
+        <footer class="task-card__footer">
+          <span class="task-card__summary">{{ TASK_STATUS_LABELS[task.status] }}任务</span>
+          <RouterLink
+            class="task-card__link"
+            :to="{
+              name: 'member-record-form',
+              params: { taskId: task.id },
+              query: buildTaskQuery(task),
+            }"
+          >
+            <el-button type="primary" plain>{{ getActionText(task.status) }}</el-button>
+          </RouterLink>
+        </footer>
+      </article>
+    </section>
+  </section>
+</template>
+
+<style scoped>
+.member-task-page {
+  display: grid;
+  gap: 20px;
+}
+
+.member-task-page__hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 24px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(64, 158, 255, 0.12), rgba(64, 158, 255, 0.03));
+}
+
+.member-task-page__hero h1 {
+  margin: 6px 0 0;
+  font-size: 24px;
+}
+
+.member-task-page__hero p {
+  margin: 10px 0 0;
+  color: var(--ui-color-text-secondary);
+  line-height: 1.6;
+}
+
+.member-task-page__eyebrow {
+  margin: 0;
+  color: var(--ui-color-primary);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.member-task-page__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.member-task-page__filter {
+  padding: 10px 16px;
+  border: none;
+  border-radius: 999px;
+  background: #eef3f8;
+  color: #425466;
+  cursor: pointer;
+  transition:
+    background-color 0.18s ease,
+    color 0.18s ease,
+    transform 0.18s ease;
+}
+
+.member-task-page__filter:hover {
+  transform: translateY(-1px);
+}
+
+.member-task-page__filter--active {
+  background: var(--ui-color-primary);
+  color: #fff;
+  box-shadow: 0 10px 22px rgba(64, 158, 255, 0.22);
+}
+
+.member-task-page__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.member-task-page__skeleton,
+.task-card {
+  padding: 20px;
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.06);
+}
+
+.member-task-page__empty {
+  color: var(--ui-color-text-secondary);
+  font-size: 14px;
+}
+
+.task-card {
+  display: grid;
+  gap: 16px;
+  border: 1px solid rgba(64, 158, 255, 0.08);
+}
+
+.task-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.task-card__header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.task-card__header p {
+  margin: 8px 0 0;
+  color: var(--ui-color-text-secondary);
+  font-size: 14px;
+}
+
+.task-card__meta {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+}
+
+.task-card__meta div {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 0;
+  border-bottom: 1px dashed rgba(148, 163, 184, 0.28);
+}
+
+.task-card__meta div:last-child {
+  border-bottom: none;
+}
+
+.task-card__meta dt {
+  color: var(--ui-color-text-secondary);
+}
+
+.task-card__meta dd {
+  margin: 0;
+  font-weight: 600;
+  text-align: right;
+}
+
+.task-card__remark {
+  margin: 0;
+  padding: 14px;
+  border-radius: 12px;
+  background: #f8fbff;
+  color: #425466;
+  line-height: 1.6;
+}
+
+.task-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.task-card__summary {
+  color: var(--ui-color-text-secondary);
+  font-size: 14px;
+}
+
+.task-card__link {
+  text-decoration: none;
+}
+
+@media (max-width: 640px) {
+  .member-task-page__hero,
+  .task-card__header,
+  .task-card__footer,
+  .task-card__meta div {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .task-card__meta dd {
+    text-align: left;
+  }
+}
+</style>

--- a/t-observer-web/src/views/member/RecordFormView.spec.ts
+++ b/t-observer-web/src/views/member/RecordFormView.spec.ts
@@ -1,0 +1,62 @@
+import ElementPlus from 'element-plus'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import RecordFormView from './RecordFormView.vue'
+
+const pushMock = vi.fn()
+const routeState = vi.hoisted(() => ({
+  params: {} as Record<string, unknown>,
+  query: {} as Record<string, unknown>,
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => routeState,
+  useRouter: () => ({
+    push: pushMock,
+  }),
+}))
+
+describe('RecordFormView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    routeState.params = {}
+    routeState.query = {}
+  })
+
+  it('shows a fallback state when task context is missing', () => {
+    const wrapper = mount(RecordFormView, {
+      global: {
+        plugins: [ElementPlus],
+      },
+    })
+
+    expect(wrapper.text()).toContain('未找到任务信息')
+    expect(wrapper.text()).toContain('返回任务列表')
+  })
+
+  it('renders task summary from route query and keeps completed tasks read-only', () => {
+    routeState.params = { taskId: '7' }
+    routeState.query = {
+      title: '高一数学听课',
+      teacherName: '赵老师',
+      courseName: '函数概念',
+      lessonTime: '2026-04-20T09:00:00',
+      deadline: '2026-04-22T18:00:00',
+      remark: '重点观察课堂互动',
+      status: 'COMPLETED',
+    }
+
+    const wrapper = mount(RecordFormView, {
+      global: {
+        plugins: [ElementPlus],
+      },
+    })
+
+    expect(wrapper.text()).toContain('听课记录填写')
+    expect(wrapper.text()).toContain('高一数学听课')
+    expect(wrapper.text()).toContain('赵老师')
+    expect(wrapper.text()).toContain('当前任务已完成，记录页切换为只读展示。')
+    expect(wrapper.text()).toContain('已完成')
+  })
+})

--- a/t-observer-web/src/views/member/RecordFormView.spec.ts
+++ b/t-observer-web/src/views/member/RecordFormView.spec.ts
@@ -2,6 +2,8 @@ import ElementPlus from 'element-plus'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { fetchRecordByTask, saveRecordDraft } from '@/api/records'
+
 import RecordFormView from './RecordFormView.vue'
 
 const pushMock = vi.fn()
@@ -17,6 +19,30 @@ vi.mock('vue-router', () => ({
   }),
 }))
 
+vi.mock('@/api/records', () => ({
+  fetchRecordByTask: vi.fn(),
+  saveRecordDraft: vi.fn(),
+  submitRecord: vi.fn(),
+}))
+
+function buildTaskQuery(status: 'PENDING' | 'IN_PROGRESS' | 'COMPLETED') {
+  return {
+    title: 'Task 7 Lesson Review',
+    teacherName: 'Teacher Zhao',
+    courseName: 'Functions',
+    lessonTime: '2026-04-20T09:00:00',
+    deadline: '2026-04-22T18:00:00',
+    remark: 'Focus on classroom interaction',
+    status,
+  }
+}
+
+async function waitForTextareas(wrapper: ReturnType<typeof mount>) {
+  await vi.waitFor(() => {
+    expect(wrapper.findAll('textarea')).toHaveLength(3)
+  })
+}
+
 describe('RecordFormView', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -31,21 +57,14 @@ describe('RecordFormView', () => {
       },
     })
 
-    expect(wrapper.text()).toContain('未找到任务信息')
+    expect(wrapper.find('.el-result').exists()).toBe(true)
     expect(wrapper.text()).toContain('返回任务列表')
   })
 
-  it('renders task summary from route query and keeps completed tasks read-only', () => {
+  it('renders task summary from route query and keeps completed tasks read-only', async () => {
     routeState.params = { taskId: '7' }
-    routeState.query = {
-      title: '高一数学听课',
-      teacherName: '赵老师',
-      courseName: '函数概念',
-      lessonTime: '2026-04-20T09:00:00',
-      deadline: '2026-04-22T18:00:00',
-      remark: '重点观察课堂互动',
-      status: 'COMPLETED',
-    }
+    routeState.query = buildTaskQuery('COMPLETED')
+    vi.mocked(fetchRecordByTask).mockResolvedValue(null)
 
     const wrapper = mount(RecordFormView, {
       global: {
@@ -53,10 +72,135 @@ describe('RecordFormView', () => {
       },
     })
 
-    expect(wrapper.text()).toContain('听课记录填写')
-    expect(wrapper.text()).toContain('高一数学听课')
-    expect(wrapper.text()).toContain('赵老师')
+    await vi.waitFor(() => {
+      expect(fetchRecordByTask).toHaveBeenCalledWith(7)
+    })
+
+    await waitForTextareas(wrapper)
+
+    expect(wrapper.text()).toContain('Task 7 Lesson Review')
+    expect(wrapper.text()).toContain('Teacher Zhao')
     expect(wrapper.text()).toContain('当前任务已完成，记录页切换为只读展示。')
-    expect(wrapper.text()).toContain('已完成')
+
+    const textareas = wrapper.findAll('textarea')
+    expect(textareas).toHaveLength(3)
+    expect(textareas.every((textarea) => textarea.element.disabled)).toBe(true)
+  })
+
+  it('loads an existing draft record for the current task', async () => {
+    routeState.params = { taskId: '7' }
+    routeState.query = buildTaskQuery('IN_PROGRESS')
+    vi.mocked(fetchRecordByTask).mockResolvedValue({
+      id: 11,
+      taskId: 7,
+      observerId: 2,
+      teacherName: 'Teacher Zhao',
+      strengths: 'Existing strengths',
+      weaknesses: 'Existing weaknesses',
+      suggestions: 'Existing suggestions',
+      status: 'DRAFT',
+      rejectReason: null,
+      submittedAt: null,
+      approvedAt: null,
+      scores: [],
+    })
+
+    const wrapper = mount(RecordFormView, {
+      global: {
+        plugins: [ElementPlus],
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(fetchRecordByTask).toHaveBeenCalledWith(7)
+    })
+
+    await waitForTextareas(wrapper)
+
+    const textareas = wrapper.findAll('textarea')
+    expect(textareas[0]?.element.value).toBe('Existing strengths')
+    expect(textareas[1]?.element.value).toBe('Existing weaknesses')
+    expect(textareas[2]?.element.value).toBe('Existing suggestions')
+  })
+
+  it('loads submitted content into the read-only view for completed tasks', async () => {
+    routeState.params = { taskId: '7' }
+    routeState.query = buildTaskQuery('COMPLETED')
+    vi.mocked(fetchRecordByTask).mockResolvedValue({
+      id: 12,
+      taskId: 7,
+      observerId: 2,
+      teacherName: 'Teacher Zhao',
+      strengths: 'Submitted strengths',
+      weaknesses: 'Submitted weaknesses',
+      suggestions: 'Submitted suggestions',
+      status: 'SUBMITTED',
+      rejectReason: null,
+      submittedAt: '2026-04-20T10:00:00',
+      approvedAt: null,
+      scores: [],
+    })
+
+    const wrapper = mount(RecordFormView, {
+      global: {
+        plugins: [ElementPlus],
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(fetchRecordByTask).toHaveBeenCalledWith(7)
+    })
+
+    await waitForTextareas(wrapper)
+
+    const textareas = wrapper.findAll('textarea')
+    expect(textareas[0]?.element.value).toBe('Submitted strengths')
+    expect(textareas[1]?.element.value).toBe('Submitted weaknesses')
+    expect(textareas[2]?.element.value).toBe('Submitted suggestions')
+    expect(textareas.every((textarea) => textarea.element.disabled)).toBe(true)
+  })
+
+  it('returns to the task list after saving a draft', async () => {
+    routeState.params = { taskId: '7' }
+    routeState.query = buildTaskQuery('PENDING')
+    vi.mocked(fetchRecordByTask).mockResolvedValue(null)
+    vi.mocked(saveRecordDraft).mockResolvedValue({
+      id: 11,
+      taskId: 7,
+      observerId: 2,
+      teacherName: 'Teacher Zhao',
+      strengths: 'Draft strengths',
+      weaknesses: '',
+      suggestions: '',
+      status: 'DRAFT',
+      rejectReason: null,
+      submittedAt: null,
+      approvedAt: null,
+      scores: [],
+    })
+
+    const wrapper = mount(RecordFormView, {
+      global: {
+        plugins: [ElementPlus],
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(fetchRecordByTask).toHaveBeenCalledWith(7)
+    })
+
+    const textareas = wrapper.findAll('textarea')
+    await textareas[0]?.setValue('Draft strengths')
+
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('保存草稿'))
+      ?.trigger('click')
+
+    await vi.waitFor(() => {
+      expect(saveRecordDraft).toHaveBeenCalled()
+    })
+
+    expect(pushMock).toHaveBeenCalledWith('/tasks')
   })
 })

--- a/t-observer-web/src/views/member/RecordFormView.vue
+++ b/t-observer-web/src/views/member/RecordFormView.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import type { AxiosError } from 'axios'
 import { ElMessage, ElMessageBox } from 'element-plus'
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
-import { saveRecordDraft, submitRecord } from '@/api/records'
+import { fetchRecordByTask, saveRecordDraft, submitRecord } from '@/api/records'
 import StatusTag from '@/components/common/StatusTag.vue'
 import DimensionScorePanel from '@/components/record/DimensionScorePanel.vue'
 import {
@@ -34,6 +34,7 @@ const scores = ref<ScoreItem[]>(createEmptyScores())
 const strengths = ref('')
 const weaknesses = ref('')
 const suggestions = ref('')
+const loadingRecord = ref(false)
 const isSavingDraft = ref(false)
 const isSubmitting = ref(false)
 const currentTaskStatus = ref<TaskStatus | null>(null)
@@ -63,6 +64,7 @@ function resolveStatus(value: unknown): TaskStatus | null {
   if (value === 'PENDING' || value === 'IN_PROGRESS' || value === 'COMPLETED') {
     return value
   }
+
   return null
 }
 
@@ -84,11 +86,8 @@ const taskContext = computed<TaskContext | null>(() => {
     !deadline ||
     !status
   ) {
-    currentTaskStatus.value = null
     return null
   }
-
-  currentTaskStatus.value = currentTaskStatus.value ?? status
 
   return {
     id: taskId,
@@ -102,7 +101,8 @@ const taskContext = computed<TaskContext | null>(() => {
   }
 })
 
-const readOnly = computed(() => currentTaskStatus.value === 'COMPLETED')
+const displayStatus = computed<TaskStatus>(() => currentTaskStatus.value ?? taskContext.value?.status ?? 'PENDING')
+const readOnly = computed(() => displayStatus.value === 'COMPLETED')
 
 function buildPayload(): RecordDraftPayload | null {
   if (!taskContext.value) {
@@ -121,9 +121,16 @@ function buildPayload(): RecordDraftPayload | null {
 
 function fillFromRecord(record: ObservationRecord) {
   scores.value = normalizeScores(record.scores)
-  strengths.value = record.strengths
-  weaknesses.value = record.weaknesses
-  suggestions.value = record.suggestions
+  strengths.value = record.strengths ?? ''
+  weaknesses.value = record.weaknesses ?? ''
+  suggestions.value = record.suggestions ?? ''
+
+  if (record.status === 'DRAFT' || record.status === 'RETURNED') {
+    currentTaskStatus.value = 'IN_PROGRESS'
+    return
+  }
+
+  currentTaskStatus.value = 'COMPLETED'
 }
 
 function validateSubmitPayload(payload: RecordDraftPayload) {
@@ -152,6 +159,25 @@ function validateSubmitPayload(payload: RecordDraftPayload) {
   return true
 }
 
+async function loadExistingRecord() {
+  if (!taskContext.value) {
+    return
+  }
+
+  loadingRecord.value = true
+
+  try {
+    const record = await fetchRecordByTask(taskContext.value.id)
+    if (record) {
+      fillFromRecord(record)
+    }
+  } catch (error) {
+    ElMessage.error(getAxiosMessage(error, '记录加载失败，请稍后重试'))
+  } finally {
+    loadingRecord.value = false
+  }
+}
+
 async function handleSaveDraft() {
   const payload = buildPayload()
   if (!payload || readOnly.value) {
@@ -163,8 +189,8 @@ async function handleSaveDraft() {
   try {
     const record = await saveRecordDraft(payload)
     fillFromRecord(record)
-    currentTaskStatus.value = 'IN_PROGRESS'
     ElMessage.success('草稿已保存')
+    await router.push('/tasks')
   } catch (error) {
     ElMessage.error(getAxiosMessage(error, '草稿保存失败，请稍后重试'))
   } finally {
@@ -191,8 +217,8 @@ async function handleSubmit() {
   isSubmitting.value = true
 
   try {
-    await submitRecord(payload)
-    currentTaskStatus.value = 'COMPLETED'
+    const record = await submitRecord(payload)
+    fillFromRecord(record)
     ElMessage.success('记录已提交')
     await router.push('/tasks')
   } catch (error) {
@@ -205,6 +231,14 @@ async function handleSubmit() {
 async function goBack() {
   await router.push('/tasks')
 }
+
+onMounted(() => {
+  if (taskContext.value) {
+    currentTaskStatus.value = taskContext.value.status
+  }
+
+  void loadExistingRecord()
+})
 </script>
 
 <template>
@@ -215,7 +249,7 @@ async function goBack() {
         <h1>听课记录填写</h1>
         <p>请围绕任务摘要完成五维评分与文本分析，支持先保存草稿再正式提交。</p>
       </div>
-      <StatusTag :status="currentTaskStatus || taskContext.status" />
+      <StatusTag :status="displayStatus" />
     </header>
 
     <el-alert
@@ -226,96 +260,106 @@ async function goBack() {
       show-icon
     />
 
-    <section class="record-form-page__task-card">
-      <div>
-        <p class="record-form-page__eyebrow">任务摘要</p>
-        <h2>{{ taskContext.title }}</h2>
-      </div>
+    <el-skeleton v-if="loadingRecord" animated>
+      <template #template>
+        <el-skeleton-item variant="p" style="width: 50%" />
+        <el-skeleton-item variant="text" style="margin-top: 12px; width: 100%" />
+        <el-skeleton-item variant="text" style="width: 80%" />
+      </template>
+    </el-skeleton>
 
-      <dl class="record-form-page__task-grid">
+    <template v-else>
+      <section class="record-form-page__task-card">
         <div>
-          <dt>授课教师</dt>
-          <dd>{{ taskContext.teacherName }}</dd>
+          <p class="record-form-page__eyebrow">任务摘要</p>
+          <h2>{{ taskContext.title }}</h2>
         </div>
-        <div>
-          <dt>课程名称</dt>
-          <dd>{{ taskContext.courseName }}</dd>
+
+        <dl class="record-form-page__task-grid">
+          <div>
+            <dt>授课教师</dt>
+            <dd>{{ taskContext.teacherName }}</dd>
+          </div>
+          <div>
+            <dt>课程名称</dt>
+            <dd>{{ taskContext.courseName }}</dd>
+          </div>
+          <div>
+            <dt>听课时间</dt>
+            <dd>{{ formatDateTime(taskContext.lessonTime) }}</dd>
+          </div>
+          <div>
+            <dt>截止时间</dt>
+            <dd>{{ formatDateTime(taskContext.deadline) }}</dd>
+          </div>
+        </dl>
+
+        <p v-if="taskContext.remark" class="record-form-page__remark">{{ taskContext.remark }}</p>
+      </section>
+
+      <DimensionScorePanel v-model="scores" :disabled="readOnly" />
+
+      <section class="record-form-page__text-grid">
+        <article class="record-form-page__text-card">
+          <header>
+            <h3>优点分析</h3>
+            <span>聚焦课堂亮点、节奏和互动设计。</span>
+          </header>
+          <el-input
+            v-model="strengths"
+            type="textarea"
+            :rows="5"
+            :disabled="readOnly"
+            placeholder="请填写本次听课中观察到的主要亮点。"
+          />
+        </article>
+
+        <article class="record-form-page__text-card">
+          <header>
+            <h3>待改进项</h3>
+            <span>可从提问深度、课堂组织或内容呈现切入。</span>
+          </header>
+          <el-input
+            v-model="weaknesses"
+            type="textarea"
+            :rows="5"
+            :disabled="readOnly"
+            placeholder="请填写需要继续改进的课堂环节。"
+          />
+        </article>
+
+        <article class="record-form-page__text-card">
+          <header>
+            <h3>改进建议</h3>
+            <span>建议尽量具体，便于后续跟进执行。</span>
+          </header>
+          <el-input
+            v-model="suggestions"
+            type="textarea"
+            :rows="5"
+            :disabled="readOnly"
+            placeholder="请填写下一步改进建议。"
+          />
+        </article>
+      </section>
+
+      <footer class="record-form-page__footer">
+        <p>草稿允许不完整保存，正式提交前需要补齐全部文本与评分。</p>
+        <div class="record-form-page__actions">
+          <el-button :disabled="readOnly" :loading="isSavingDraft" @click="handleSaveDraft">
+            保存草稿
+          </el-button>
+          <el-button
+            type="primary"
+            :disabled="readOnly"
+            :loading="isSubmitting"
+            @click="handleSubmit"
+          >
+            提交记录
+          </el-button>
         </div>
-        <div>
-          <dt>听课时间</dt>
-          <dd>{{ formatDateTime(taskContext.lessonTime) }}</dd>
-        </div>
-        <div>
-          <dt>截止时间</dt>
-          <dd>{{ formatDateTime(taskContext.deadline) }}</dd>
-        </div>
-      </dl>
-
-      <p v-if="taskContext.remark" class="record-form-page__remark">{{ taskContext.remark }}</p>
-    </section>
-
-    <DimensionScorePanel v-model="scores" :disabled="readOnly" />
-
-    <section class="record-form-page__text-grid">
-      <article class="record-form-page__text-card">
-        <header>
-          <h3>优点分析</h3>
-          <span>聚焦课堂亮点、节奏和互动设计。</span>
-        </header>
-        <el-input
-          v-model="strengths"
-          type="textarea"
-          :rows="5"
-          :disabled="readOnly"
-          placeholder="请填写本次听课中观察到的主要亮点。"
-        />
-      </article>
-
-      <article class="record-form-page__text-card">
-        <header>
-          <h3>待改进项</h3>
-          <span>可从提问深度、课堂组织或内容呈现切入。</span>
-        </header>
-        <el-input
-          v-model="weaknesses"
-          type="textarea"
-          :rows="5"
-          :disabled="readOnly"
-          placeholder="请填写需要继续改进的课堂环节。"
-        />
-      </article>
-
-      <article class="record-form-page__text-card">
-        <header>
-          <h3>改进建议</h3>
-          <span>建议尽量具体，便于后续跟进执行。</span>
-        </header>
-        <el-input
-          v-model="suggestions"
-          type="textarea"
-          :rows="5"
-          :disabled="readOnly"
-          placeholder="请填写下一步改进建议。"
-        />
-      </article>
-    </section>
-
-    <footer class="record-form-page__footer">
-      <p>草稿允许不完整保存，正式提交前需要补齐全部文本与评分。</p>
-      <div class="record-form-page__actions">
-        <el-button :disabled="readOnly" :loading="isSavingDraft" @click="handleSaveDraft">
-          保存草稿
-        </el-button>
-        <el-button
-          type="primary"
-          :disabled="readOnly"
-          :loading="isSubmitting"
-          @click="handleSubmit"
-        >
-          提交记录
-        </el-button>
-      </div>
-    </footer>
+      </footer>
+    </template>
   </section>
 
   <el-result

--- a/t-observer-web/src/views/member/RecordFormView.vue
+++ b/t-observer-web/src/views/member/RecordFormView.vue
@@ -1,0 +1,467 @@
+<script setup lang="ts">
+import type { AxiosError } from 'axios'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { computed, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import { saveRecordDraft, submitRecord } from '@/api/records'
+import StatusTag from '@/components/common/StatusTag.vue'
+import DimensionScorePanel from '@/components/record/DimensionScorePanel.vue'
+import {
+  createEmptyScores,
+  normalizeScores,
+  type ObservationRecord,
+  type RecordDraftPayload,
+  type ScoreItem,
+} from '@/types/record'
+import type { TaskStatus } from '@/types/task'
+
+type TaskContext = {
+  id: number
+  title: string
+  teacherName: string
+  courseName: string
+  lessonTime: string
+  deadline: string
+  remark: string
+  status: TaskStatus
+}
+
+const route = useRoute()
+const router = useRouter()
+
+const scores = ref<ScoreItem[]>(createEmptyScores())
+const strengths = ref('')
+const weaknesses = ref('')
+const suggestions = ref('')
+const isSavingDraft = ref(false)
+const isSubmitting = ref(false)
+const currentTaskStatus = ref<TaskStatus | null>(null)
+
+function formatDateTime(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return new Intl.DateTimeFormat('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
+}
+
+function getAxiosMessage(error: unknown, fallback: string) {
+  return (
+    ((error as AxiosError<{ message?: string }>)?.response?.data?.message ?? '').trim() || fallback
+  )
+}
+
+function resolveStatus(value: unknown): TaskStatus | null {
+  if (value === 'PENDING' || value === 'IN_PROGRESS' || value === 'COMPLETED') {
+    return value
+  }
+  return null
+}
+
+const taskContext = computed<TaskContext | null>(() => {
+  const taskId = Number(route.params.taskId)
+  const title = String(route.query.title ?? '').trim()
+  const teacherName = String(route.query.teacherName ?? '').trim()
+  const courseName = String(route.query.courseName ?? '').trim()
+  const lessonTime = String(route.query.lessonTime ?? '').trim()
+  const deadline = String(route.query.deadline ?? '').trim()
+  const status = resolveStatus(route.query.status)
+
+  if (
+    !Number.isFinite(taskId) ||
+    !title ||
+    !teacherName ||
+    !courseName ||
+    !lessonTime ||
+    !deadline ||
+    !status
+  ) {
+    currentTaskStatus.value = null
+    return null
+  }
+
+  currentTaskStatus.value = currentTaskStatus.value ?? status
+
+  return {
+    id: taskId,
+    title,
+    teacherName,
+    courseName,
+    lessonTime,
+    deadline,
+    remark: String(route.query.remark ?? ''),
+    status,
+  }
+})
+
+const readOnly = computed(() => currentTaskStatus.value === 'COMPLETED')
+
+function buildPayload(): RecordDraftPayload | null {
+  if (!taskContext.value) {
+    return null
+  }
+
+  return {
+    taskId: taskContext.value.id,
+    teacherName: taskContext.value.teacherName,
+    strengths: strengths.value.trim(),
+    weaknesses: weaknesses.value.trim(),
+    suggestions: suggestions.value.trim(),
+    scores: normalizeScores(scores.value),
+  }
+}
+
+function fillFromRecord(record: ObservationRecord) {
+  scores.value = normalizeScores(record.scores)
+  strengths.value = record.strengths
+  weaknesses.value = record.weaknesses
+  suggestions.value = record.suggestions
+}
+
+function validateSubmitPayload(payload: RecordDraftPayload) {
+  if (!payload.strengths || !payload.weaknesses || !payload.suggestions) {
+    ElMessage.warning('请先补全优点、待改进项和改进建议。')
+    return false
+  }
+
+  const normalizedScores = normalizeScores(payload.scores)
+  const completedScores = normalizedScores.filter((score) => typeof score.scoreValue === 'number')
+
+  if (completedScores.length !== 5) {
+    ElMessage.warning('提交前请完成全部 5 个维度评分。')
+    return false
+  }
+
+  if (
+    completedScores.some(
+      (score) => score.scoreValue === null || score.scoreValue < 1 || score.scoreValue > 5,
+    )
+  ) {
+    ElMessage.warning('评分必须处于 1.0 到 5.0 之间。')
+    return false
+  }
+
+  return true
+}
+
+async function handleSaveDraft() {
+  const payload = buildPayload()
+  if (!payload || readOnly.value) {
+    return
+  }
+
+  isSavingDraft.value = true
+
+  try {
+    const record = await saveRecordDraft(payload)
+    fillFromRecord(record)
+    currentTaskStatus.value = 'IN_PROGRESS'
+    ElMessage.success('草稿已保存')
+  } catch (error) {
+    ElMessage.error(getAxiosMessage(error, '草稿保存失败，请稍后重试'))
+  } finally {
+    isSavingDraft.value = false
+  }
+}
+
+async function handleSubmit() {
+  const payload = buildPayload()
+  if (!payload || readOnly.value || !validateSubmitPayload(payload)) {
+    return
+  }
+
+  try {
+    await ElMessageBox.confirm('提交后任务将进入已完成状态，确认继续吗？', '确认提交', {
+      type: 'warning',
+      confirmButtonText: '确认提交',
+      cancelButtonText: '取消',
+    })
+  } catch {
+    return
+  }
+
+  isSubmitting.value = true
+
+  try {
+    await submitRecord(payload)
+    currentTaskStatus.value = 'COMPLETED'
+    ElMessage.success('记录已提交')
+    await router.push('/tasks')
+  } catch (error) {
+    ElMessage.error(getAxiosMessage(error, '提交失败，请检查填写内容后重试'))
+  } finally {
+    isSubmitting.value = false
+  }
+}
+
+async function goBack() {
+  await router.push('/tasks')
+}
+</script>
+
+<template>
+  <section v-if="taskContext" class="record-form-page">
+    <header class="record-form-page__hero">
+      <div class="record-form-page__hero-main">
+        <el-button text type="primary" @click="goBack">返回任务列表</el-button>
+        <h1>听课记录填写</h1>
+        <p>请围绕任务摘要完成五维评分与文本分析，支持先保存草稿再正式提交。</p>
+      </div>
+      <StatusTag :status="currentTaskStatus || taskContext.status" />
+    </header>
+
+    <el-alert
+      v-if="readOnly"
+      title="当前任务已完成，记录页切换为只读展示。"
+      type="success"
+      :closable="false"
+      show-icon
+    />
+
+    <section class="record-form-page__task-card">
+      <div>
+        <p class="record-form-page__eyebrow">任务摘要</p>
+        <h2>{{ taskContext.title }}</h2>
+      </div>
+
+      <dl class="record-form-page__task-grid">
+        <div>
+          <dt>授课教师</dt>
+          <dd>{{ taskContext.teacherName }}</dd>
+        </div>
+        <div>
+          <dt>课程名称</dt>
+          <dd>{{ taskContext.courseName }}</dd>
+        </div>
+        <div>
+          <dt>听课时间</dt>
+          <dd>{{ formatDateTime(taskContext.lessonTime) }}</dd>
+        </div>
+        <div>
+          <dt>截止时间</dt>
+          <dd>{{ formatDateTime(taskContext.deadline) }}</dd>
+        </div>
+      </dl>
+
+      <p v-if="taskContext.remark" class="record-form-page__remark">{{ taskContext.remark }}</p>
+    </section>
+
+    <DimensionScorePanel v-model="scores" :disabled="readOnly" />
+
+    <section class="record-form-page__text-grid">
+      <article class="record-form-page__text-card">
+        <header>
+          <h3>优点分析</h3>
+          <span>聚焦课堂亮点、节奏和互动设计。</span>
+        </header>
+        <el-input
+          v-model="strengths"
+          type="textarea"
+          :rows="5"
+          :disabled="readOnly"
+          placeholder="请填写本次听课中观察到的主要亮点。"
+        />
+      </article>
+
+      <article class="record-form-page__text-card">
+        <header>
+          <h3>待改进项</h3>
+          <span>可从提问深度、课堂组织或内容呈现切入。</span>
+        </header>
+        <el-input
+          v-model="weaknesses"
+          type="textarea"
+          :rows="5"
+          :disabled="readOnly"
+          placeholder="请填写需要继续改进的课堂环节。"
+        />
+      </article>
+
+      <article class="record-form-page__text-card">
+        <header>
+          <h3>改进建议</h3>
+          <span>建议尽量具体，便于后续跟进执行。</span>
+        </header>
+        <el-input
+          v-model="suggestions"
+          type="textarea"
+          :rows="5"
+          :disabled="readOnly"
+          placeholder="请填写下一步改进建议。"
+        />
+      </article>
+    </section>
+
+    <footer class="record-form-page__footer">
+      <p>草稿允许不完整保存，正式提交前需要补齐全部文本与评分。</p>
+      <div class="record-form-page__actions">
+        <el-button :disabled="readOnly" :loading="isSavingDraft" @click="handleSaveDraft">
+          保存草稿
+        </el-button>
+        <el-button
+          type="primary"
+          :disabled="readOnly"
+          :loading="isSubmitting"
+          @click="handleSubmit"
+        >
+          提交记录
+        </el-button>
+      </div>
+    </footer>
+  </section>
+
+  <el-result
+    v-else
+    icon="warning"
+    title="未找到任务信息"
+    sub-title="请从任务列表重新进入该记录页面。"
+  >
+    <template #extra>
+      <el-button type="primary" @click="goBack">返回任务列表</el-button>
+    </template>
+  </el-result>
+</template>
+
+<style scoped>
+.record-form-page {
+  display: grid;
+  gap: 20px;
+}
+
+.record-form-page__hero,
+.record-form-page__task-card,
+.record-form-page__text-card,
+.record-form-page__footer {
+  padding: 24px;
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.06);
+}
+
+.record-form-page__hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  background: linear-gradient(135deg, rgba(64, 158, 255, 0.12), rgba(64, 158, 255, 0.03));
+}
+
+.record-form-page__hero-main h1 {
+  margin: 8px 0 0;
+  font-size: 24px;
+}
+
+.record-form-page__hero-main p {
+  margin: 10px 0 0;
+  color: var(--ui-color-text-secondary);
+  line-height: 1.6;
+}
+
+.record-form-page__eyebrow {
+  margin: 0;
+  color: var(--ui-color-primary);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.record-form-page__task-card h2 {
+  margin: 6px 0 0;
+  font-size: 20px;
+}
+
+.record-form-page__task-grid,
+.record-form-page__text-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.record-form-page__task-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin: 20px 0 0;
+}
+
+.record-form-page__task-grid div {
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: #f8fbff;
+}
+
+.record-form-page__task-grid dt {
+  color: var(--ui-color-text-secondary);
+  font-size: 13px;
+}
+
+.record-form-page__task-grid dd {
+  margin: 10px 0 0;
+  font-weight: 600;
+}
+
+.record-form-page__remark {
+  margin: 16px 0 0;
+  color: var(--ui-color-text-secondary);
+  line-height: 1.6;
+}
+
+.record-form-page__text-grid {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.record-form-page__text-card {
+  display: grid;
+  gap: 14px;
+}
+
+.record-form-page__text-card header h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.record-form-page__text-card header span {
+  display: block;
+  margin-top: 6px;
+  color: var(--ui-color-text-secondary);
+  font-size: 14px;
+}
+
+.record-form-page__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.record-form-page__footer p {
+  margin: 0;
+  color: var(--ui-color-text-secondary);
+}
+
+.record-form-page__actions {
+  display: flex;
+  gap: 12px;
+}
+
+@media (max-width: 768px) {
+  .record-form-page__hero,
+  .record-form-page__footer {
+    flex-direction: column;
+  }
+
+  .record-form-page__actions {
+    width: 100%;
+  }
+
+  .record-form-page__actions :deep(.el-button) {
+    flex: 1;
+  }
+}
+</style>


### PR DESCRIPTION
﻿## What changed
- add Task 7 frontend task list, record form, and leader management views
- wire task-related frontend routing and shell navigation
- add task and record API wrappers plus shared status/score UI pieces

## Why
- establish the Task 7 MVP frontend baseline for issue #8
- keep the initial implementation reviewable as a draft before layering bug fixes

## Impact
- members can enter the task list and record form flow
- leaders can open the task management flow and create tasks from the frontend
- this PR is intentionally left as draft because follow-up fixes are being added on top

## Validation
- `npx vitest run src/router/index.spec.ts src/views/member/MemberTaskListView.spec.ts src/views/member/RecordFormView.spec.ts src/views/leader/LeaderTaskManageView.spec.ts`
- `npm run type-check`
- `npm run build`
